### PR TITLE
Redesign Project section of homepage with two-column card layout

### DIFF
--- a/src/routes/(default)/landing-page/SectionProject.svelte
+++ b/src/routes/(default)/landing-page/SectionProject.svelte
@@ -1,11 +1,47 @@
-<div class="py-20 justify-center flex-col max-w-7xl mx-auto gap-x-4 lg:gap-x-24 grid lg:grid-cols-2">
-	<div>
-		<span class="block font-bold text-3xl mb-3">The PROVIDE project</span>
-		<p class="leading-normal text-base sm:text-lg">
-			The PROVIDE project is a Horizon Europe funded consortium of scientists and policy experts, working to develop new, faster ways to project
-			climate impacts, and ultimately, provide information on how we can avoid them. The project, aside from developing new scientific methods, aims
-			to provide more clarity on how climate impacts might develop after peak temperatures, in so-called 'overshoot scenarios', and if they can be
-			reversed.
-		</p>
+<section class="pt-20 pb-12">
+	<h2 class="text-3xl tracking-wide text-theme-stronger font-normal mb-8">
+		Learn about the Climate Risk<br />Dashboard project
+	</h2>
+
+	<div class="grid md:grid-cols-2 gap-6">
+		<div class="border border-contour-weakest p-6 flex flex-col">
+			<p class="text-base text-text-base leading-relaxed mb-8 flex-grow">
+				This platform brings together research from <strong>PROVIDE</strong> a
+				<a href="#" class="text-theme-base hover:underline">Horizon Europe consortium</a>
+				developing faster ways to project climate impacts and analyse overshoot pathways.
+				<strong>SPARCCLE</strong>, which supplies
+				<a href="#" class="text-theme-base hover:underline">EU focused indicators</a>, traffic-light comparisons, and data for the Scoreboard, and
+				<strong>[New project]</strong>, which will add further models, scenarios, and sectors. Together, these projects contribute the datasets,
+				methods, and documentation that power the charts and maps you see here.
+			</p>
+			<a href="#" class="text-theme-base hover:underline font-medium mt-auto">Learn more</a>
+		</div>
+
+		<div class="border border-contour-weakest p-6 flex flex-col">
+			<p class="text-base text-text-base mb-6">The Climate Risk Dashboard combines:</p>
+
+			<div class="space-y-4 flex-grow">
+				<div>
+					<h3 class="text-sm font-medium text-theme-base uppercase tracking-wide">Projections across scales</h3>
+					<p class="text-sm text-text-base">
+						Country- and grid-level projections under multiple scenarios show how indicators change over time and place.
+					</p>
+				</div>
+
+				<div>
+					<h3 class="text-sm font-medium text-theme-base uppercase tracking-wide">Ensemble methods & uncertainty</h3>
+					<p class="text-sm text-text-base">
+						Time-series and maps come from model ensembles, summarized with medians and confidence ranges (5th–95th percentiles).
+					</p>
+				</div>
+
+				<div>
+					<h3 class="text-sm font-medium text-theme-base uppercase tracking-wide">(Un)avoidable risk</h3>
+					<p class="text-sm text-text-base">Views that estimate the likelihood of crossing chosen impact levels.</p>
+				</div>
+			</div>
+
+			<a href="#" class="text-theme-base hover:underline font-medium mt-8 block">View methodology</a>
+		</div>
 	</div>
-</div>
+</section>


### PR DESCRIPTION
## Summary
- Restructures the project section into a two-column grid with bordered cards
- Left card: PROVIDE, SPARCCLE, and new project info with "Learn more" link
- Right card: Dashboard methodology highlights (projections, ensemble methods, risk) with "View methodology" link
- Uses flexbox to ensure bottom-aligned links in both cards

## Test plan
- [ ] Verify two-column layout displays correctly on desktop
- [ ] Test responsive behavior on mobile (should stack)
- [ ] Confirm links are aligned at bottom of cards regardless of content height
- [ ] Check styling matches design mockup

🤖 Generated with [Claude Code](https://claude.com/claude-code)