### PR TITLE
Dynamic popover placement and mobile render order for explore controls

### DIFF
--- a/src/lib/controls/ExploreControls/GeographySelection/GeographySelection.svelte
+++ b/src/lib/controls/ExploreControls/GeographySelection/GeographySelection.svelte
@@ -11,6 +11,7 @@
   import LoadingWrapper from '$lib/helper/LoadingWrapper.svelte';
 
   export let label = 'Geography';
+  export let popperOptions = {};
 
   let GEO_SHAPE_DATA = writable({});
 
@@ -74,6 +75,7 @@
   panelClass="w-screen-p max-w-4xl"
   buttonClass="border-theme-base/20 border aria-expanded:border-theme-base/60"
   placeholder={$IS_EMPTY_GEOGRAPHY ? 'Select a geography' : undefined}
+  {popperOptions}
 >
   <Content filters={geographyTypes} filterKey="geographyType" filterLabel="Pick a location" currentUid={$CURRENT_GEOGRAPHY_UID} items={selectableGeographies} bind:currentFilterUid allowWrap={true}>
     <div slot="items" let:items let:currentFilterUid class="max-w-full grid grid-cols-1 md:grid-cols-[1.5fr_3fr] lg:grid-cols-[1.5fr_3fr]">

--- a/src/lib/controls/ExploreControls/IndicatorSelection/IndicatorSelection.svelte
+++ b/src/lib/controls/ExploreControls/IndicatorSelection/IndicatorSelection.svelte
@@ -5,6 +5,7 @@
   import { derived } from 'svelte/store';
 
   export let label = 'Indicator';
+  export let popperOptions = {};
 
   let currentFilterUid;
 
@@ -25,6 +26,7 @@
   warning={!$IS_EMPTY_INDICATOR && !$IS_COMBINATION_AVAILABLE_INDICATOR ? 'Selected indicator is not available for this geography' : undefined}
   disabled={$DISABLED}
   placeholder={$IS_EMPTY_INDICATOR ? 'Select an indicator' : undefined}
+  {popperOptions}
 >
   <Content
     filters={$SELECTABLE_SECTORS}

--- a/src/lib/controls/ExploreControls/SelectionControls.svelte
+++ b/src/lib/controls/ExploreControls/SelectionControls.svelte
@@ -27,7 +27,7 @@
   class:grid-cols-1={true}
 >
   <div class="order-1" class:md:order-1={mode === 'geography'} class:md:order-3={mode === 'indicator'}>
-    <GeographySelection label={geographyLabel} />
+    <GeographySelection label={geographyLabel} popperOptions={{ placement: mode === 'geography' ? 'bottom-start' : 'bottom-end' }} />
   </div>
 
   <div class="hidden md:flex items-center justify-center order-2 pt-8">
@@ -35,6 +35,6 @@
   </div>
 
   <div class="order-3" class:md:order-3={mode === 'geography'} class:md:order-1={mode === 'indicator'}>
-    <IndicatorSelection label={indicatorLabel} />
+    <IndicatorSelection label={indicatorLabel} popperOptions={{ placement: mode === 'geography' ? 'bottom-end' : 'bottom-start' }} />
   </div>
 </div>

--- a/src/lib/controls/ExploreControls/SelectionControls.svelte
+++ b/src/lib/controls/ExploreControls/SelectionControls.svelte
@@ -26,7 +26,7 @@
   class:md:grid-cols-[1fr_auto_1fr]={true}
   class:grid-cols-1={true}
 >
-  <div class="order-1" class:md:order-1={mode === 'geography'} class:md:order-3={mode === 'indicator'}>
+  <div class:order-1={mode === 'geography'} class:order-3={mode === 'indicator'} class:md:order-1={mode === 'geography'} class:md:order-3={mode === 'indicator'}>
     <GeographySelection label={geographyLabel} popperOptions={{ placement: mode === 'geography' ? 'bottom-start' : 'bottom-end' }} />
   </div>
 
@@ -34,7 +34,7 @@
     <SwapButton on:click={toggleMode} />
   </div>
 
-  <div class="order-3" class:md:order-3={mode === 'geography'} class:md:order-1={mode === 'indicator'}>
+  <div class:order-3={mode === 'geography'} class:order-1={mode === 'indicator'} class:md:order-3={mode === 'geography'} class:md:order-1={mode === 'indicator'}>
     <IndicatorSelection label={indicatorLabel} popperOptions={{ placement: mode === 'geography' ? 'bottom-end' : 'bottom-start' }} />
   </div>
 </div>

--- a/src/lib/controls/PopoverSelect/PopoverSelect.svelte
+++ b/src/lib/controls/PopoverSelect/PopoverSelect.svelte
@@ -16,6 +16,8 @@
   /** @type {string|undefined} Holds a disabled text that is conditionally displayed. This can happen if the user needs to select another option first */
   export let disabled = undefined;
   export let category = undefined;
+  /** @type {Object} Popper.js options to merge with defaults */
+  export let popperOptions = {};
 
   $: isDisabled = Boolean(disabled);
 
@@ -32,10 +34,17 @@
 
   const [popperRef, popperContent] = createPopperActions();
 
-  $: popperOptions = {
+  const defaultModifiers = [
+    { name: 'offset', options: { offset: [0, 10] } },
+    { name: 'flip', enabled: true },
+    { name: 'preventOverflow', options: { padding: 8 } },
+  ];
+
+  $: resolvedPopperOptions = {
     placement: panelPlacement,
     strategy: 'fixed',
-    modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
+    ...popperOptions,
+    modifiers: [...defaultModifiers, ...(popperOptions.modifiers ?? [])],
   };
 </script>
 
@@ -70,7 +79,7 @@
     <ExpandIcon class="min-w-[20px] grow-1 stroke-current" isOpen={open} />
   </PopoverButton>
 
-  <PopoverPanel use={[[popperContent, popperOptions]]} class={`${panelClass} bg-surface-base rounded overflow-hidden border-contour-weakest border shadow-xl z-50 relative`} let:open>
+  <PopoverPanel use={[[popperContent, resolvedPopperOptions]]} class={`${panelClass} bg-surface-base rounded overflow-hidden border-contour-weakest border shadow-xl z-50 relative`} let:open>
     <slot />
   </PopoverPanel>
 </Popover>


### PR DESCRIPTION
UPB-9, UPB-6

## Summary

- Makes the geography/indicator popover placement dynamic based on which selector is on the left vs right (avoids popovers clipping off-screen)
- Fixes mobile render order so the first-step control always appears on top when mode changes

## Test plan

- [ ] In geography mode: Geography popover opens bottom-start, Indicator opens bottom-end
- [ ] Switch to indicator mode: Indicator popover opens bottom-start, Geography opens bottom-end
- [ ] On mobile: switching modes correctly reorders the controls so step 1 appears first

🤖 Generated with [Claude Code](https://claude.com/claude-code)