### PR TITLE
Add reusable PageLayout component and apply to explore/avoid pages

### DIFF
--- a/src/lib/controls/ExploreControls/ControlTabs.svelte
+++ b/src/lib/controls/ExploreControls/ControlTabs.svelte
@@ -2,8 +2,7 @@
   import { RadioGroup, RadioGroupOption } from '@rgossiaux/svelte-headlessui';
   import Globe from '$lib/helper/icons/Globe.svelte';
   import Chart from '$lib/helper/icons/Chart.svelte';
-
-  export let mode = 'geography';
+  import { SELECTION_MODE } from '$stores/state.js';
 
   const tabs = [
     {
@@ -19,7 +18,7 @@
   ];
 </script>
 
-<RadioGroup bind:value={mode} class="flex gap-x-6">
+<RadioGroup bind:value={$SELECTION_MODE} class="flex gap-x-6">
   {#each tabs as { value, label, icon }}
     <RadioGroupOption {value} let:checked class="cursor-pointer">
       <div

--- a/src/lib/controls/ExploreControls/IndicatorSelection/IndicatorParameters.svelte
+++ b/src/lib/controls/ExploreControls/IndicatorSelection/IndicatorParameters.svelte
@@ -22,13 +22,11 @@
     });
 </script>
 
-<div class="flex flex-wrap" id="indicator-parameters">
-  {#each parametersSorted as parameter}
-    <Select
-      disabled={!$IS_COMBINATION_AVAILABLE_INDICATOR}
-      {...parameter}
-      wrapperClass={`flex-col border-r border-contour-weakest py-4 px-6`}
-      on:change={handleChange}
-    />
-  {/each}
-</div>
+{#each parametersSorted as parameter}
+  <Select
+    disabled={!$IS_COMBINATION_AVAILABLE_INDICATOR}
+    {...parameter}
+    wrapperClass={`flex-col`}
+    on:change={handleChange}
+  />
+{/each}

--- a/src/lib/controls/ExploreControls/SelectionControls.svelte
+++ b/src/lib/controls/ExploreControls/SelectionControls.svelte
@@ -1,16 +1,10 @@
 <script>
   import GeographySelection from './GeographySelection/GeographySelection.svelte';
   import IndicatorSelection from './IndicatorSelection/IndicatorSelection.svelte';
-  import ControlTabs from './ControlTabs.svelte';
   import SwapButton from './SwapButton.svelte';
   import { SELECTION_MODE } from '$stores/state.js';
 
-  export let sticky = false;
-
-  let mode = $SELECTION_MODE;
-
-  // Sync local mode variable to the store so other components can react to it
-  $: SELECTION_MODE.set(mode);
+  $: mode = $SELECTION_MODE;
 
   $: geographyStep = mode === 'geography' ? 1 : 2;
   $: indicatorStep = mode === 'geography' ? 2 : 1;
@@ -19,19 +13,11 @@
   $: indicatorLabel = `Step ${indicatorStep} - Indicator`;
 
   function toggleMode() {
-    mode = mode === 'geography' ? 'indicator' : 'geography';
+    SELECTION_MODE.set(mode === 'geography' ? 'indicator' : 'geography');
   }
 </script>
 
-<div class="bg-slate-50 pt-8">
-  <div class="mx-auto max-w-7xl px-6">
-    <ControlTabs bind:mode />
-  </div>
-</div>
-
-<hr class="border-t border-contour-weakest" />
-
-<div class="bg-slate-50 py-6 z-50" class:md:sticky={sticky} class:md:top-0={sticky} class:md:border-b={sticky} class:md:border-contour-weakest={sticky}>
+<div class="bg-slate-50 py-6 z-50">
   <div
     class="grid gap-4 md:gap-6 items-center mx-auto max-w-7xl px-6"
     class:md:grid-cols-[1fr_auto_1fr]={true}

--- a/src/lib/controls/PopoverSelect/PopoverSelect.svelte
+++ b/src/lib/controls/PopoverSelect/PopoverSelect.svelte
@@ -37,7 +37,7 @@
   };
 </script>
 
-<Popover class={`relative w-full ${$$restProps.class}`}>
+<Popover class={$$restProps.class}>
   <span class={`uppercase text-xs tracking-widest font-bold text-contour-weak inline-block ${labelClass}`}>{label}</span>
   <PopoverButton
     use={[popperRef]}

--- a/src/lib/helper/ScrollContent/SimpleNav.svelte
+++ b/src/lib/helper/ScrollContent/SimpleNav.svelte
@@ -12,7 +12,7 @@
     class:pointer-events-none={disabled}
     role={disabled ? 'link' : undefined}
     href={disabled ? undefined : `#${slug}`}
-    class="hidden md:inline-block py-3 pl-2 -ml-2 pr-6 lg:pr-12 border-r-3 hover:bg-surface-weaker"
+    class="md:inline-block py-3 pl-2 -ml-2 pr-6 lg:pr-12 border-r-3 hover:bg-surface-weaker"
     class:border-theme-base={isActive}
     class:border-transparent={!isActive}
     aria-current={isActive ? 'step' : 'false'}

--- a/src/lib/helper/ScrollContent/SimpleNav.svelte
+++ b/src/lib/helper/ScrollContent/SimpleNav.svelte
@@ -4,7 +4,9 @@
   // role="link" -> https://www.scottohara.me/blog/2021/05/28/disabled-links.html
 </script>
 
-{#each sections.filter(({ slug }) => slug) as { slug, title, description, disabled }, i}
+{#each sections as section, i}
+  {#if section.slug}
+  {@const { slug, title, description, disabled } = section}
   {@const isActive = activeIndex === i}
   <a
     class:cursor-not-allowed={disabled}
@@ -24,4 +26,5 @@
       {description}
     </div>
   </a>
+  {/if}
 {/each}

--- a/src/lib/site/PageLayout.svelte
+++ b/src/lib/site/PageLayout.svelte
@@ -10,12 +10,14 @@
 </div>
 
 <div class="relative grid grid-rows-[auto_auto] grid-cols-1 md:grid-cols-[280px_1fr] md:grid-rows-1 mx-auto max-w-7xl">
-  <div class="md:pl-6 md:py-6 flex flex-col gap-4 md:sticky h-fit" style="top: {navHeight}px">
+  <div class="pl-6 py-6 flex flex-col gap-4 md:sticky h-fit" style="top: {navHeight}px">
     <slot name="sidebar" />
   </div>
   <div class="md:border-l border-contour-weakest border-t md:border-t-0">
-    <div class="flex md:sticky bg-white border-b border-contour-weakest z-20" style="top: {navHeight}px">
-      <slot name="filters" />
+    <div class="md:sticky z-20" style="top: {navHeight}px">
+      <div class="flex h-fit bg-white border-b border-contour-weakest [&>*]:border-r [&>*]:border-contour-weakest [&>*]:px-6 [&>*]:py-4">
+        <slot name="filters" />
+      </div>
     </div>
     <div class="px-6 py-12">
       <slot name="content" />

--- a/src/lib/site/PageLayout.svelte
+++ b/src/lib/site/PageLayout.svelte
@@ -1,0 +1,24 @@
+<script>
+  let navHeight = 0;
+</script>
+
+
+<slot name="hero" />
+
+<div bind:clientHeight={navHeight} class="relative md:sticky md:top-0 z-50">
+  <slot name="nav" />
+</div>
+
+<div class="relative grid grid-rows-[auto_auto] grid-cols-1 md:grid-cols-[280px_1fr] md:grid-rows-1 mx-auto max-w-7xl">
+  <div class="md:pl-6 md:py-6 flex flex-col gap-4 md:sticky h-fit" style="top: {navHeight}px">
+    <slot name="sidebar" />
+  </div>
+  <div class="md:border-l border-contour-weakest border-t md:border-t-0">
+    <div class="flex md:sticky bg-white border-b border-contour-weakest z-20" style="top: {navHeight}px">
+      <slot name="filters" />
+    </div>
+    <div class="px-6 py-12">
+      <slot name="content" />
+    </div>
+  </div>
+</div>

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -1,13 +1,9 @@
 <script>
   import ThresholdLevels from './ThresholdLevels/ThresholdLevels.svelte';
   import StudyLocations from './StudyLocations/StudyLocations.svelte';
-  import UnAvoidableRisk from '../UnavoidableRisk/UnavoidableRisk.svelte';
-  import Reference from './Reference/Reference.svelte';
   import SimpleNav from '$lib/helper/ScrollContent/SimpleNav.svelte';
-  import { IS_COMBINATION_AVAILABLE, IS_EMPTY_SELECTION, SELECTABLE_SCENARIOS } from '$stores/state';
+  import { IS_COMBINATION_AVAILABLE, IS_EMPTY_SELECTION } from '$stores/state';
   import { IS_EMPTY_LEVEL_OF_IMPACT, IS_EMPTY_LIKELIHOOD_LEVEL } from '$stores/avoid.js';
-  import { SCENARIOS_IN_AVOIDING_IMPACTS, KEY_SCENARIO_ENDYEAR } from '$config';
-  import THEME from '$styles/theme-store.js';
   import FallbackMessage from '$lib/helper/FallbackMessage.svelte';
   import SelectionCertaintyLevels from './Selection/CertaintyLevels/CertaintyLevels.svelte';
   import SelectionStudyLocations from './Selection/StudyLocations/StudyLocations.svelte';
@@ -15,14 +11,11 @@
   import PageHero from '$lib/site/PageHero.svelte';
   import { SelectionControls } from '$lib/controls/ExploreControls';
   import ImpactLevel from './Reference/ImpactLevel.svelte';
+  import PageLayout from '$lib/site/PageLayout.svelte';
 
   $: isValidSelection = !$IS_EMPTY_SELECTION && $IS_COMBINATION_AVAILABLE && !$IS_EMPTY_LEVEL_OF_IMPACT && !$IS_EMPTY_LIKELIHOOD_LEVEL;
 
   let THRESHOLD_LEVELS_DATA = writable({});
-
-  $: currentScenarios = SCENARIOS_IN_AVOIDING_IMPACTS.map((uid) => $SELECTABLE_SCENARIOS.find((scenario) => scenario.uid === uid))
-    .filter(Boolean)
-    .map(({ uid, label, [KEY_SCENARIO_ENDYEAR]: timeframe }, i) => ({ uid, label, [KEY_SCENARIO_ENDYEAR]: timeframe, color: $THEME.color.category.base[i] }));
 
   $: sections = [
     { component: FallbackMessage, disabled: isValidSelection },
@@ -32,10 +25,7 @@
       description: 'When will the impact level be exceeded?',
       component: ThresholdLevels,
       disabled: !isValidSelection,
-      props: {
-        store: THRESHOLD_LEVELS_DATA,
-        tagline: 'Impact Level',
-      },
+      props: { store: THRESHOLD_LEVELS_DATA, tagline: 'Impact Level' },
     },
     {
       slug: 'locations',
@@ -43,21 +33,8 @@
       description: 'When will the impact level be exceeded across different locations?',
       component: StudyLocations,
       disabled: !isValidSelection,
-      props: {
-        store: THRESHOLD_LEVELS_DATA,
-        tagline: 'Locations',
-      },
+      props: { store: THRESHOLD_LEVELS_DATA, tagline: 'Locations' },
     },
-    // {
-    //   slug: 'unavoidable-risk',
-    //   title: '(Un)avoidable risk',
-    //   description: 'What can be avoided through emissions reductions?',
-    //   component: UnAvoidableRisk,
-    //   disabled: !isValidSelection,
-    //   props: {
-    //     currentScenarios: currentScenarios,
-    //   },
-    // },
   ];
 
   let activeIndex = 0;
@@ -72,28 +49,32 @@
   }
 </script>
 
-<PageHero className="bg-petrol-900" label="PROVIDE" title="Avoiding future impacts" description="Explore which scenarios minimise the risk from certain impacts in cities and their rural surroundings. Understand the likelihood of exceeding the impact levels you would like to avoid." />
+<PageLayout>
+  <svelte:fragment slot="hero">
+    <PageHero className="bg-petrol-900" label="PROVIDE" title="Avoiding future impacts" description="Explore which scenarios minimise the risk from certain impacts in cities and their rural surroundings. Understand the likelihood of exceeding the impact levels you would like to avoid." />
+  </svelte:fragment>
 
-<SelectionControls sticky />
+  <svelte:fragment slot="nav">
+    <SelectionControls sticky />
+  </svelte:fragment>
 
-<div class="relative grid grid-rows-[auto_auto] grid-cols-1 md:grid-cols-[280px_1fr] md:grid-rows-1 mx-auto max-w-7xl">
-  <nav class="md:pl-6 md:py-6 flex flex-col gap-4 md:sticky md:top-[129px] h-fit">
+  <svelte:fragment slot="sidebar">
     <SimpleNav {sections} {activeIndex} />
-  </nav>
-  <div class="md:border-l border-contour-weakest border-t md:border-t-0">
-    <div class="flex md:sticky md:top-[129px] z-20 bg-white border-b border-contour-weakest">
+  </svelte:fragment>
+
+  <svelte:fragment slot="filters">
       <ImpactLevel />
       <SelectionCertaintyLevels />
       <SelectionStudyLocations />
-    </div>
-    <div class="relative px-6 py-12">
-      {#each sections as section, i}
-        {#if !section.disabled}
-          <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-16 border-b pb-14 border-contour-weaker last:border-none">
-            <svelte:component this={section.component} {...section.props} />
-          </section>
-        {/if}
-      {/each}
-    </div>
-  </div>
-</div>
+  </svelte:fragment>
+
+  <svelte:fragment slot="content">
+    {#each sections as section, i}
+      {#if !section.disabled}
+        <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-16 border-b pb-14 border-contour-weaker last:border-none">
+          <svelte:component this={section.component} {...section.props} />
+        </section>
+      {/if}
+    {/each}
+  </svelte:fragment>
+</PageLayout>

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -52,16 +52,17 @@
 <PageLayout>
   <svelte:fragment slot="hero">
     <PageHero className="bg-petrol-900" label="PROVIDE" title="Avoiding future impacts" description="Explore which scenarios minimise the risk from certain impacts in cities and their rural surroundings. Understand the likelihood of exceeding the impact levels you would like to avoid." />
-  </svelte:fragment>
-
-  <svelte:fragment slot="nav">
     <div class="bg-slate-50 pt-8">
       <div class="mx-auto max-w-7xl px-6">
         <ControlTabs />
       </div>
     </div>
     <hr class="border-t border-contour-weakest" />
+  </svelte:fragment>
+
+  <svelte:fragment slot="nav">
     <SelectionControls />
+    <div class="border-b border-contour-weakest" />
   </svelte:fragment>
 
   <svelte:fragment slot="sidebar">

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -9,7 +9,7 @@
   import SelectionStudyLocations from './Selection/StudyLocations/StudyLocations.svelte';
   import { writable } from 'svelte/store';
   import PageHero from '$lib/site/PageHero.svelte';
-  import { SelectionControls } from '$lib/controls/ExploreControls';
+  import { SelectionControls, ControlTabs } from '$lib/controls/ExploreControls';
   import ImpactLevel from './Reference/ImpactLevel.svelte';
   import PageLayout from '$lib/site/PageLayout.svelte';
 
@@ -55,7 +55,13 @@
   </svelte:fragment>
 
   <svelte:fragment slot="nav">
-    <SelectionControls sticky />
+    <div class="bg-slate-50 pt-8">
+      <div class="mx-auto max-w-7xl px-6">
+        <ControlTabs />
+      </div>
+    </div>
+    <hr class="border-t border-contour-weakest" />
+    <SelectionControls />
   </svelte:fragment>
 
   <svelte:fragment slot="sidebar">

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -63,9 +63,9 @@
   </svelte:fragment>
 
   <svelte:fragment slot="filters">
-      <ImpactLevel />
-      <SelectionCertaintyLevels />
-      <SelectionStudyLocations />
+    <ImpactLevel />
+    <SelectionCertaintyLevels />
+    <SelectionStudyLocations />
   </svelte:fragment>
 
   <svelte:fragment slot="content">

--- a/src/routes/(default)/impacts/explore/+page.svelte
+++ b/src/routes/(default)/impacts/explore/+page.svelte
@@ -3,12 +3,12 @@
   import ImpactGeo from './ImpactGeo/ImpactGeo.svelte';
   import UnAvoidableRisk from '../UnavoidableRisk/UnavoidableRisk.svelte';
   import ScenarioSelection from './ScenarioSelection/ScenarioSelection.svelte';
-  import SimpleNav from '$lib/helper/ScrollContent/SimpleNav.svelte';
   import { IS_COMBINATION_AVAILABLE, IS_EMPTY_SELECTION } from '$stores/state';
   import FallbackMessage from '$lib/helper/FallbackMessage.svelte';
-  import { IndicatorParameters } from '$lib/controls/ExploreControls';
+  import { IndicatorParameters, SelectionControls } from '$lib/controls/ExploreControls';
   import PageHero from '$lib/site/PageHero.svelte';
-  import { SelectionControls } from '$lib/controls/ExploreControls';
+  import PageLayout from '$lib/site/PageLayout.svelte';
+  import SimpleNav from '$lib/helper/ScrollContent/SimpleNav.svelte';
 
   $: isValidSelection = !$IS_EMPTY_SELECTION && $IS_COMBINATION_AVAILABLE;
 
@@ -19,9 +19,7 @@
       description: 'How will this climate impact change?',
       component: ImpactTime,
       disabled: !isValidSelection,
-      props: {
-        tagline: 'Timing',
-      },
+      props: { tagline: 'Timing' },
     },
     {
       slug: 'impact-geo',
@@ -29,9 +27,7 @@
       description: 'Where will impacts hit the hardest?',
       component: ImpactGeo,
       disabled: !isValidSelection,
-      props: {
-        tagline: 'Location',
-      },
+      props: { tagline: 'Location' },
     },
     {
       slug: 'unavoidable-risk',
@@ -39,9 +35,7 @@
       description: 'What can be avoided through emissions reductions?',
       component: UnAvoidableRisk,
       disabled: !isValidSelection,
-      props: {
-        tagline: '(Un)avoidable risk',
-      },
+      props: { tagline: '(Un)avoidable risk' },
     },
     { component: FallbackMessage, disabled: isValidSelection },
   ];
@@ -58,28 +52,33 @@
   }
 </script>
 
-<PageHero label="EXPLORER" title="Future impacts" description="Explore how different levels of climate action will lead to different climate impacts for countries, cities, and more. See where risk escalates and under what conditions impacts could be avoided." />
+<PageLayout navHeight={198}>
+  <svelte:fragment slot="hero">
+    <PageHero label="EXPLORER" title="Future impacts" description="Explore how different levels of climate action will lead to different climate impacts for countries, cities, and more. See where risk escalates and under what conditions impacts could be avoided." />
+  </svelte:fragment>
 
-<SelectionControls sticky />
+  <svelte:fragment slot="nav">
+    <SelectionControls />
+    <div class="border-b border-contour-weakest " />
+  </svelte:fragment>
 
-<div class="relative grid grid-rows-[auto_auto] grid-cols-1 md:grid-cols-[280px_1fr] md:grid-rows-1 mx-auto max-w-7xl">
-  <nav class="md:pl-6 md:py-6 flex flex-col gap-4 md:sticky md:top-[128px] h-fit">
+  <svelte:fragment slot="sidebar">
     <h2 class="font-display text-xs uppercase text-theme-800 font-semibold tracking-wide">Report Index</h2>
     <SimpleNav {sections} {activeIndex} />
-  </nav>
-  <div class="md:border-l border-contour-weakest border-t md:border-t-0">
-    <div class="flex md:sticky md:top-[128px] z-20 bg-white border-b border-contour-weakest">
-      <ScenarioSelection />
-      <IndicatorParameters/>
-    </div>
-    <div class="relative px-6 py-12">
-      {#each sections as section, i}
-        {#if !section.disabled}
-          <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-16 pb-14 border-contour-weakest border-b last:border-none">
-            <svelte:component this={section.component} {...section.props} />
-          </section>
-        {/if}
-      {/each}
-    </div>
-  </div>
-</div>
+  </svelte:fragment>
+
+  <svelte:fragment slot="filters">
+    <ScenarioSelection />
+    <IndicatorParameters />
+  </svelte:fragment>
+
+  <svelte:fragment slot="content">
+    {#each sections as section, i}
+      {#if !section.disabled}
+        <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-16 pb-14 border-contour-weakest border-b last:border-none">
+          <svelte:component this={section.component} {...section.props} />
+        </section>
+      {/if}
+    {/each}
+  </svelte:fragment>
+</PageLayout>

--- a/src/routes/(default)/impacts/explore/+page.svelte
+++ b/src/routes/(default)/impacts/explore/+page.svelte
@@ -52,7 +52,7 @@
   }
 </script>
 
-<PageLayout navHeight={198}>
+<PageLayout>
   <svelte:fragment slot="hero">
     <PageHero label="EXPLORER" title="Future impacts" description="Explore how different levels of climate action will lead to different climate impacts for countries, cities, and more. See where risk escalates and under what conditions impacts could be avoided." />
     <div class="bg-slate-50 pt-8">
@@ -64,7 +64,6 @@
   </svelte:fragment>
 
   <svelte:fragment slot="nav">
-
     <SelectionControls />
     <div class="border-b border-contour-weakest" />
   </svelte:fragment>

--- a/src/routes/(default)/impacts/explore/+page.svelte
+++ b/src/routes/(default)/impacts/explore/+page.svelte
@@ -5,7 +5,7 @@
   import ScenarioSelection from './ScenarioSelection/ScenarioSelection.svelte';
   import { IS_COMBINATION_AVAILABLE, IS_EMPTY_SELECTION } from '$stores/state';
   import FallbackMessage from '$lib/helper/FallbackMessage.svelte';
-  import { IndicatorParameters, SelectionControls } from '$lib/controls/ExploreControls';
+  import { IndicatorParameters, SelectionControls, ControlTabs } from '$lib/controls/ExploreControls';
   import PageHero from '$lib/site/PageHero.svelte';
   import PageLayout from '$lib/site/PageLayout.svelte';
   import SimpleNav from '$lib/helper/ScrollContent/SimpleNav.svelte';
@@ -55,11 +55,18 @@
 <PageLayout navHeight={198}>
   <svelte:fragment slot="hero">
     <PageHero label="EXPLORER" title="Future impacts" description="Explore how different levels of climate action will lead to different climate impacts for countries, cities, and more. See where risk escalates and under what conditions impacts could be avoided." />
+    <div class="bg-slate-50 pt-8">
+      <div class="mx-auto max-w-7xl px-6">
+        <ControlTabs />
+      </div>
+    </div>
+    <hr class="border-t border-contour-weakest" />
   </svelte:fragment>
 
   <svelte:fragment slot="nav">
+
     <SelectionControls />
-    <div class="border-b border-contour-weakest " />
+    <div class="border-b border-contour-weakest" />
   </svelte:fragment>
 
   <svelte:fragment slot="sidebar">

--- a/src/routes/(default)/impacts/explore/ImpactGeo/Controls.svelte
+++ b/src/routes/(default)/impacts/explore/ImpactGeo/Controls.svelte
@@ -14,7 +14,7 @@
   $: yearOptionsList = yearOptions.map((year) => ({ uid: year, label: String(year) }));
 </script>
 
-<div class="flex gap-6">
+<div class="flex items-center gap-6">
   {#if scenarios.length === 2}
     <SegmentedControl options={displayOptions} bind:value={displayOption} />
   {/if}

--- a/src/routes/(default)/impacts/explore/ScenarioSelection/ScenarioSelection.svelte
+++ b/src/routes/(default)/impacts/explore/ScenarioSelection/ScenarioSelection.svelte
@@ -58,51 +58,49 @@
 
 <svelte:window bind:innerWidth={windowWidth} />
 
-<div class="border-r border-contour-weakest px-6 py-4">
-  <PopoverSelect
-    label="Scenario"
-    {buttonLabel}
-    panelClass="w-screen-p max-w-4xl"
-    labelClass="mb-0 p-0 text-text-stronger uppercase text-xs leading-tight"
-    buttonClass="text-sm p-0"
-    class="flex flex-col gap-2 h-full justify-center"
-    warning={!$IS_EMPTY_INDICATOR && hasScenarioSelected && !$IS_COMBINATION_AVAILABLE_SCENARIO ? `Unavailable scenario${multipleScenariosSelected ? 's' : ''} selected` : undefined}
-    placeholder={!hasScenarioSelected ? 'Select one or more scenarios' : undefined}
-    size="md"
-    disabled={$DISABLED}
+<PopoverSelect
+  label="Scenario"
+  {buttonLabel}
+  panelClass="w-screen-p max-w-4xl"
+  labelClass="mb-0 p-0 text-text-stronger uppercase text-xs leading-tight"
+  buttonClass="text-sm p-0"
+  class="flex flex-col gap-2"
+  warning={!$IS_EMPTY_INDICATOR && hasScenarioSelected && !$IS_COMBINATION_AVAILABLE_SCENARIO ? `Unavailable scenario${multipleScenariosSelected ? 's' : ''} selected` : undefined}
+  placeholder={!hasScenarioSelected ? 'Select one or more scenarios' : undefined}
+  size="md"
+  disabled={$DISABLED}
+>
+  <Content
+    filters={$AVAILABLE_TIMEFRAMES}
+    filterKey="endYear"
+    filterLabel="Pick a timeframe"
+    disabledMessage="No scenarios available for this indicator in this timeframe"
+    currentUid={$CURRENT_SCENARIOS_UID}
+    bind:currentFilterUid={currentTimeframe}
+    items={scenarios}
   >
-    <Content
-      filters={$AVAILABLE_TIMEFRAMES}
-      filterKey="endYear"
-      filterLabel="Pick a timeframe"
-      disabledMessage="No scenarios available for this indicator in this timeframe"
-      currentUid={$CURRENT_SCENARIOS_UID}
-      bind:currentFilterUid={currentTimeframe}
-      items={scenarios}
+    <a
+      slot="header-link"
+      class="text-sm leading-tight font-bold flex items-center rounded-sm bg-petrol-800 text-white px-3 sm:px-4 md:px-6 py-1 sm:py-2 md:py-3 gap-2 hover:bg-petrol-900 transition-colors"
+      href={`/${PATH_KEY_CONCEPTS}#${ANCHOR_EXPLAINER_SCENARIOS}`}
     >
-      <a
-        slot="header-link"
-        class="text-sm leading-tight font-bold flex items-center rounded-sm bg-petrol-800 text-white px-3 sm:px-4 md:px-6 py-1 sm:py-2 md:py-3 gap-2 hover:bg-petrol-900 transition-colors"
-        href={`/${PATH_KEY_CONCEPTS}#${ANCHOR_EXPLAINER_SCENARIOS}`}
-      >
-        <span>Which scenario should I select?</span>
-        <LinkArrow />
-      </a>
-      <div slot="items" class="grid grid-cols-1 md:grid-cols-[auto_1fr]" let:items let:currentFilterUid>
-        {#key currentFilterUid}
-          <fieldset class="flex flex-col min-w-min md:border-r border-contour-weakest py-2">
-            <ScenarioList highlightedScenarioUid={renderedScenario?.uid} bind:hoveredScenarioUid scenarios={items} {currentFilterUid} />
-          </fieldset>
-        {/key}
+      <span>Which scenario should I select?</span>
+      <LinkArrow />
+    </a>
+    <div slot="items" class="grid grid-cols-1 md:grid-cols-[auto_1fr]" let:items let:currentFilterUid>
+      {#key currentFilterUid}
+        <fieldset class="flex flex-col min-w-min md:border-r border-contour-weakest py-2">
+          <ScenarioList highlightedScenarioUid={renderedScenario?.uid} bind:hoveredScenarioUid scenarios={items} {currentFilterUid} />
+        </fieldset>
+      {/key}
 
-        <div class="p-6 hidden md:block">
-          {#if renderedScenario}
-            <ScenarioDetails scenario={renderedScenario} scenarios={chartScenarios} {currentFilterUid} />
-          {:else}
-            <div class="p-4 flex items-center rounded text-contour-weak justify-center min-h-[60vh]">Hover over a scenario to view details</div>
-          {/if}
-        </div>
+      <div class="p-6 hidden md:block">
+        {#if renderedScenario}
+          <ScenarioDetails scenario={renderedScenario} scenarios={chartScenarios} {currentFilterUid} />
+        {:else}
+          <div class="p-4 flex items-center rounded text-contour-weak justify-center min-h-[60vh]">Hover over a scenario to view details</div>
+        {/if}
       </div>
-    </Content>
-  </PopoverSelect>
-</div>
+    </div>
+  </Content>
+</PopoverSelect>

--- a/src/routes/(default)/landing-page/SectionExplore.svelte
+++ b/src/routes/(default)/landing-page/SectionExplore.svelte
@@ -3,7 +3,7 @@
   import { PATH_EXPLORE, PATH_IMPACT, URL_PATH_GEOGRAPHY, URL_PATH_INDICATOR } from '$config';
   import { IS_EMPTY_GEOGRAPHY, IS_EMPTY_INDICATOR, IS_COMBINATION_AVAILABLE_INDICATOR, CURRENT_GEOGRAPHY_UID, CURRENT_INDICATOR_UID } from '$stores/state.js';
   import { buildURL } from '$lib/utils/url.js';
-  import { SelectionControls } from '$lib/controls/ExploreControls';
+  import { SelectionControls, ControlTabs } from '$lib/controls/ExploreControls';
   import LinkArrow from '$lib/helper/icons/LinkArrow.svelte';
   import Button from '$lib/controls/Button/Button.svelte';
 
@@ -29,6 +29,12 @@
   </header>
 
   <div class="md:pt-16 pb-6 md:pb-12 bg-slate-50 border-t border-contour-weakest">
+    <div class="pt-8">
+      <div class="mx-auto max-w-7xl px-6">
+        <ControlTabs />
+      </div>
+    </div>
+    <hr class="border-t border-contour-weakest" />
     <SelectionControls />
     <div class="flex justify-end mt-8 px-6">
     <Button disabled={!isValidSelection} on:click={viewResults}>


### PR DESCRIPTION
## Summary
- Extracts shared page layout (hero, sticky nav, sidebar, sticky filters, scrollable content) into a reusable `PageLayout.svelte` component using named slots
- Applies the new layout to both the explore and avoid impact pages
- Moves sticky control offset calculation into the layout using `bind:clientHeight` on the nav, replacing hardcoded pixel values
- Fixes slug index issue in avoid pages

## Test plan
- [ ] Verify explore page layout and sticky behavior still works correctly
- [ ] Verify avoid page layout and sticky behavior still works correctly
- [ ] Check that sidebar and filter sticky offsets respond dynamically to nav height changes
- [ ] Confirm no regressions on landing page SectionExplore component

🤖 Generated with [Claude Code](https://claude.com/claude-code)