### PR TITLE
Remove sticky positioning from contact page image

### DIFF
--- a/src/routes/(default)/contact/+page.svelte
+++ b/src/routes/(default)/contact/+page.svelte
@@ -18,12 +18,12 @@
         <HtmlContent content={text} />
       </div>
     </div>
-    <div class="hidden md:block relative">
+    <div class="hidden md:block">
       <img
         src="/img/contact-bg.png"
         alt=""
         aria-hidden="true"
-        class="sticky top-0 h-screen w-full object-cover"
+        class="w-full object-cover"
       />
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Removes `sticky top-0 h-screen` from the contact page background image
- Image now displays naturally at the top of the column rather than staying fixed while content scrolls

🤖 Generated with [Claude Code](https://claude.ai/claude-code)