### PR TITLE
Surface reference context sentence in threshold-levels section

### DIFF
--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -78,6 +78,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="sidebar">
+    <h2 class="font-display text-xs uppercase text-theme-800 font-semibold tracking-wide">Report Index</h2>
     <SimpleNav {sections} {activeIndex} />
     <hr class="my-4 border-contour-weakest mr-6" />
     <ShareLink />

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -17,6 +17,7 @@
   import ShareLink from '../components/ShareLink/ShareLink.svelte';
   import Button from '$lib/components/ui/Button.svelte';
   import LinkArrow from '$lib/components/icons/LinkArrow.svelte';
+  import IndicatorFilters from '../explore/components/IndicatorFilters.svelte';
 
   onMount(() => HEADER_CLASS.set('bg-[#1F2B59] border-petrol-800/50'));
   onDestroy(() => HEADER_CLASS.set(''));
@@ -90,6 +91,7 @@
     <ImpactLevel />
     <SelectionCertaintyLevels />
     <SelectionStudyLocations />
+    <IndicatorFilters />
   </svelte:fragment>
 
   <svelte:fragment slot="content">

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -11,7 +11,7 @@
   import PageHero from '$lib/components/layouts/PageHero.svelte';
   import ParameterSelection from '$lib/components/controls/ParameterSelection.svelte';
   import ModeSelectionTabs from '$lib/components/controls/ModeSelectionTabs.svelte';
-  import ImpactLevel from './components/Reference/ImpactLevel.svelte';
+  import Reference from './components/Reference/Reference.svelte';
   import PageLayout from '$lib/components/layouts/PageLayout.svelte';
   import { onMount, onDestroy } from 'svelte';
   import ShareLink from '../components/ShareLink/ShareLink.svelte';
@@ -88,7 +88,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="filters">
-    <ImpactLevel />
+    <Reference />
     <SelectionCertaintyLevels />
     <SelectionStudyLocations />
     <IndicatorFilters />

--- a/src/routes/(default)/impacts/avoid/components/Reference/ImpactLevel.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/ImpactLevel.svelte
@@ -1,10 +1,18 @@
+<script context="module">
+  // These persist across component remounts (e.g. popover close/reopen) so we can
+  // distinguish a genuine data change from a remount with the same data.
+  let _lastMin = null;
+  let _lastMax = null;
+  let _lastDefault = null;
+</script>
+
 <script>
   import { LEVEL_OF_IMPACT } from '$stores/avoid.js';
   import { CURRENT_INDICATOR } from '$stores/state.js';
   import { formatUnit, formatValue } from '$lib/utils/formatting';
   import { scaleLinear } from 'd3-scale';
   import { createSlider, melt } from '@melt-ui/svelte';
-  import { writable } from 'svelte/store';
+  import { writable, get } from 'svelte/store';
   import { round } from 'lodash-es';
   import { format } from 'd3-format';
   import Knob from './Slider/Knob.svelte';
@@ -28,13 +36,20 @@
   let thumb;
 
   function updateSlider(min, max, defaultValue) {
-    value = writable([defaultValue]);
-    LEVEL_OF_IMPACT.set(rv(defaultValue));
+    const paramsChanged = min !== _lastMin || max !== _lastMax || defaultValue !== _lastDefault;
+    _lastMin = min;
+    _lastMax = max;
+    _lastDefault = defaultValue;
+
+    // On remount with unchanged data (popover reopen), restore the user's selection.
+    // On first load or data change (new indicator/geography), use defaultValue.
+    const initialValue = !paramsChanged ? get(LEVEL_OF_IMPACT) + offset : defaultValue;
+
+    value = writable([initialValue]);
     const {
       elements: { root: r, thumb: t },
     } = createSlider({
-      // defaultValue: [min], // This has to be an array because of MeltUI's workings
-      defaultValue: [defaultValue],
+      defaultValue: [initialValue],
       min: min,
       max: max,
       step: step,

--- a/src/routes/(default)/impacts/avoid/components/Reference/ImpactLevel.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/ImpactLevel.svelte
@@ -1,78 +1,83 @@
 <script>
-  import { CURRENT_INDICATOR_OPTION_VALUES, IS_EMPTY_GEOGRAPHY, CURRENT_GEOGRAPHY, CURRENT_INDICATOR, IS_COMBINATION_AVAILABLE_INDICATOR, IS_EMPTY_INDICATOR } from '$stores/state.js';
-  import { SELECTED_STUDY_LOCATION, LEVEL_OF_IMPACT } from '$stores/avoid.js';
-  import { END_AVOIDING_REFERENCE, URL_PATH_GEOGRAPHY, URL_PATH_INDICATOR, URL_PATH_STUDY_LOCATION, STATUS_SUCCESS } from '$config';
-  import { fetchData } from '$lib/api/api';
+  import { LEVEL_OF_IMPACT } from '$stores/avoid.js';
+  import { CURRENT_INDICATOR } from '$stores/state.js';
   import { formatUnit, formatValue } from '$lib/utils/formatting';
+  import { scaleLinear } from 'd3-scale';
+  import { createSlider, melt } from '@melt-ui/svelte';
   import { writable } from 'svelte/store';
-  import { round, floor, ceil, range } from 'lodash-es';
-  import { mean } from 'd3-array';
-  import Select from '$lib/components/ui/Select.svelte';
+  import { round } from 'lodash-es';
+  import { format } from 'd3-format';
+  import Knob from './Slider/Knob.svelte';
 
-  let store = writable({});
+  let value = writable([0]);
 
-  $: unit = $CURRENT_INDICATOR?.unit;
+  export let data;
 
-  $: !$IS_EMPTY_GEOGRAPHY &&
-    !$IS_EMPTY_INDICATOR &&
-    $IS_COMBINATION_AVAILABLE_INDICATOR &&
-    fetchData(store, {
-      endpoint: END_AVOIDING_REFERENCE,
-      params: {
-        [URL_PATH_GEOGRAPHY]: $CURRENT_GEOGRAPHY.uid,
-        [URL_PATH_INDICATOR]: $CURRENT_INDICATOR.uid,
-        ...$CURRENT_INDICATOR_OPTION_VALUES,
-        [URL_PATH_STUDY_LOCATION]: $SELECTED_STUDY_LOCATION,
-      },
+  $: ({ unit } = $CURRENT_INDICATOR);
+
+  // The step size of the slider
+  $: ({ step, min, max, totalMin, totalMax, defaultValue, offset, decimals } = data);
+
+  $: rv = (value) => round(value, decimals); // We round the value with the amount of decimals places as the step size
+  $: fv = format(`.${decimals}f`); // This is used to always have the same decimals places. Even if values are for example *.0
+
+  // This is used to calculate the range of interest position
+  $: scaleX = scaleLinear().domain([totalMin, totalMax]).range([0, 100]);
+
+  let root;
+  let thumb;
+
+  function updateSlider(min, max, defaultValue) {
+    value = writable([defaultValue]);
+    LEVEL_OF_IMPACT.set(rv(defaultValue));
+    const {
+      elements: { root: r, thumb: t },
+    } = createSlider({
+      // defaultValue: [min], // This has to be an array because of MeltUI's workings
+      defaultValue: [defaultValue],
+      min: min,
+      max: max,
+      step: step,
+      value: value,
     });
 
-  function getDecimalsOfNumber(n) {
-    const parts = String(n).split('.');
-    return parts.length === 2 ? parts[1].length : 0;
-  }
-  function floorNumber(v, offset, step, decimals) {
-    return floor(Math.floor((v + offset) / step) * step, decimals);
-  }
-  function ceilNumber(v, offset, step, decimals) {
-    return ceil(Math.floor((v + offset) / step) * step, decimals);
-  }
+    root = r;
+    thumb = t;
 
-  let options = [];
-  let selectedValue;
-
-  $: if ($store?.status === STATUS_SUCCESS) {
-    const raw = $store.data;
-    const step = raw.impact_levels.step;
-    const decimals = getDecimalsOfNumber(step);
-    const [min, max] = raw.impact_levels.range_of_interest;
-    const [totalMin, totalMax] = raw.impact_levels.total;
-    const offset = Math.min(0, totalMin) * -1;
-    const tMin = floorNumber(totalMin, offset, step, decimals);
-    const tMax = ceilNumber(totalMax, offset, step, decimals);
-    const defaultValue = round(Math.round(mean([min + offset, max + offset]) / step) * step, decimals);
-
-    options = range(tMin, tMax + step, step).map((v) => {
-      const actual = round(v - offset, decimals);
-      return {
-        value: actual,
-        label: `${formatValue(actual, unit?.uid, { decimals })}`,
-      };
+    value.subscribe((value) => {
+      LEVEL_OF_IMPACT.set(rv(value[0] - offset));
     });
-
-    selectedValue = round(defaultValue - offset, decimals);
-    LEVEL_OF_IMPACT.set(selectedValue);
   }
+
+  // This is triggered everytime the min value changes.
+  $: updateSlider(totalMin, totalMax, defaultValue);
 </script>
 
-{#if options.length}
-  <Select
-    label="Level of Impact"
-    {options}
-    value={selectedValue}
-    wrapperClass="flex-col border-r border-contour-weakest py-4 px-6"
-    on:change={({ detail }) => {
-      selectedValue = detail.value;
-      LEVEL_OF_IMPACT.set(detail.value);
-    }}
-  />
-{/if}
+<div class="mr-2">
+  <div class="font-bold text-text-weaker mb-2 flex justify-between">
+    <span class="uppercase text-xs tracking-widest">Level of Impact</span>
+    <span class="text-xs text-theme-base">
+      {formatValue($LEVEL_OF_IMPACT, unit.uid, { decimals })}{@html formatUnit(unit)}
+    </span>
+  </div>
+
+  <div>
+    {#if root}
+      <span use:melt={$root} class="relative flex h-[20px] w-full items-center">
+        <span class="block h-[7px] w-full bg-contour-weakest rounded-full"> </span>
+        <span class="absolute block h-[7px] bg-theme-base" style="left: {scaleX(min)}%; width: {scaleX(max) - scaleX(min)}%;" title="Range of interest"></span>
+        <span
+          use:melt={$thumb()}
+          class="flex items-center justify-center h-6 w-6 rounded-full bg-surface-weakest shadow-sm border-contour-weakest border focus:ring-1 text-theme-base focus:ring-theme-base"
+        >
+          <Knob />
+        </span>
+      </span>
+      <div class="grid grid-cols-[1fr_2fr_1fr] text-xs text-contour-weaker">
+        <span>{formatValue(totalMin - offset, unit.uid, { decimals })}{@html formatUnit(unit)}</span>
+        <span class="text-theme-weaker font-normal text-center">Level of interest</span>
+        <span class="text-right">{formatValue(totalMax - offset, unit.uid, { decimals })}{@html formatUnit(unit)}</span>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
@@ -1,18 +1,27 @@
 <script>
   import { CURRENT_INDICATOR_OPTION_VALUES, IS_EMPTY_GEOGRAPHY, CURRENT_GEOGRAPHY, CURRENT_INDICATOR, TEMPLATE_PROPS, IS_COMBINATION_AVAILABLE_INDICATOR, IS_EMPTY_INDICATOR } from '$stores/state.js';
-  import { SELECTED_STUDY_LOCATION, REFERENCE_PROCESSED } from '$stores/avoid.js';
+  import { SELECTED_STUDY_LOCATION, REFERENCE_PROCESSED, LEVEL_OF_IMPACT } from '$stores/avoid.js';
   import LoadingWrapper from '$lib/components/ui/LoadingWrapper.svelte';
   import LoadingPlaceholder from '$lib/components/ui/LoadingPlaceholder.svelte';
   import { END_AVOIDING_REFERENCE, URL_PATH_GEOGRAPHY, URL_PATH_INDICATOR, URL_PATH_STUDY_LOCATION } from '$config';
   import { fetchData } from '$lib/api/api';
-  import Text from './Text.svelte';
   import ImpactLevel from './ImpactLevel.svelte';
-  import Message from '$lib/components/ui/Message.svelte';
   import { mean } from 'd3-array';
   import { round, floor, ceil } from 'lodash-es';
   import { writable } from 'svelte/store';
+  import { Popover, PopoverButton, PopoverPanel } from '@rgossiaux/svelte-headlessui';
+  import { createPopperActions } from 'svelte-popperjs';
+  import ExpandIcon from '$lib/components/icons/Expand.svelte';
+  import { formatValue, formatUnit } from '$lib/utils/formatting';
 
   const store = writable({});
+
+  const [popperRef, popperContent] = createPopperActions();
+  const popperOptions = {
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
+  };
 
   $: !$IS_EMPTY_GEOGRAPHY &&
     !$IS_EMPTY_INDICATOR &&
@@ -61,39 +70,41 @@
       countable,
     };
     REFERENCE_PROCESSED.set(processed);
+    LEVEL_OF_IMPACT.set(round(defaultValue - offset, decimals));
     return { data: processed };
   };
+
+  $: $store?.data && process({ data: $store });
+
+  $: ({ unit } = $CURRENT_INDICATOR ?? {});
+  $: ({ decimals } = $REFERENCE_PROCESSED ?? {});
+  $: triggerValue = $REFERENCE_PROCESSED
+    ? `${formatValue($LEVEL_OF_IMPACT, unit?.uid, { decimals })}${formatUnit(unit)}`
+    : '—';
 </script>
 
-<div class="flex flex-col gap-y-6">
-  {#if !$IS_EMPTY_GEOGRAPHY && !$IS_EMPTY_INDICATOR && $IS_COMBINATION_AVAILABLE_INDICATOR}
-    <LoadingWrapper
-      {process}
-      let:asyncProps={{ data }}
-      asyncProps={{
-        data: $store,
-      }}
-      props={{
-        ...$TEMPLATE_PROPS,
-      }}
-      warningSizeSmall={true}
-      warningBackground={false}
-    >
-      <ImpactLevel {data} />
+<Popover class="relative">
+  <PopoverButton use={[popperRef]} let:open class="flex flex-col gap-2 w-full text-left focus:outline-none">
+    <span class="uppercase text-xs tracking-widest font-bold text-contour-weak inline-block">Level of Impact</span>
+    <span class="flex w-full rounded-sm text-sm bg-surface-base justify-between items-center truncate text-theme-base font-bold">
+      <span class="leading-tight truncate">{@html triggerValue}</span>
+      <ExpandIcon class="min-w-[20px] stroke-current stroke-[1.5]" />
+    </span>
+  </PopoverButton>
 
-      <LoadingPlaceholder slot="placeholder" />
-    </LoadingWrapper>
-  {:else if $IS_EMPTY_GEOGRAPHY}
-    <Message warningBackground={false} warningSizeSmall={true} headline="No geography selected">
-      <span>Select a geography from the dropdown at the top of this page.</span>
-    </Message>
-  {:else if $IS_EMPTY_INDICATOR}
-    <Message warningBackground={false} warningSizeSmall={true} headline="No indicator selected">
-      <span>Select an indicator from the dropdown at the top of this page.</span>
-    </Message>
-  {:else}
-    <Message warningBackground={false} warningSizeSmall={true} headline="Combination not available">
-      <span>Select an indicator from the dropdown at the top of this page.</span>
-    </Message>
-  {/if}
-</div>
+  <PopoverPanel use={[[popperContent, popperOptions]]} class="bg-surface-base shadow-md z-50 rounded border-contour-weakest border p-4 w-72">
+    {#if !$IS_EMPTY_GEOGRAPHY && !$IS_EMPTY_INDICATOR && $IS_COMBINATION_AVAILABLE_INDICATOR}
+      <LoadingWrapper
+        {process}
+        let:asyncProps={{ data }}
+        asyncProps={{ data: $store }}
+        props={{ ...$TEMPLATE_PROPS }}
+        warningSizeSmall={true}
+        warningBackground={false}
+      >
+        <ImpactLevel {data} />
+        <LoadingPlaceholder slot="placeholder" />
+      </LoadingWrapper>
+    {/if}
+  </PopoverPanel>
+</Popover>

--- a/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
@@ -16,6 +16,8 @@
 
   const store = writable({});
 
+  let _lastProcessedDefault = null;
+
   const [popperRef, popperContent] = createPopperActions();
   const popperOptions = {
     placement: 'bottom-start',
@@ -70,7 +72,11 @@
       countable,
     };
     REFERENCE_PROCESSED.set(processed);
-    LEVEL_OF_IMPACT.set(round(defaultValue - offset, decimals));
+    const newLevelDefault = round(defaultValue - offset, decimals);
+    if (newLevelDefault !== _lastProcessedDefault) {
+      LEVEL_OF_IMPACT.set(newLevelDefault);
+      _lastProcessedDefault = newLevelDefault;
+    }
     return { data: processed };
   };
 

--- a/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/Reference.svelte
@@ -1,16 +1,18 @@
 <script>
   import { CURRENT_INDICATOR_OPTION_VALUES, IS_EMPTY_GEOGRAPHY, CURRENT_GEOGRAPHY, CURRENT_INDICATOR, TEMPLATE_PROPS, IS_COMBINATION_AVAILABLE_INDICATOR, IS_EMPTY_INDICATOR } from '$stores/state.js';
-  import { SELECTED_STUDY_LOCATION } from '$stores/avoid.js';
+  import { SELECTED_STUDY_LOCATION, REFERENCE_PROCESSED } from '$stores/avoid.js';
   import LoadingWrapper from '$lib/components/ui/LoadingWrapper.svelte';
   import LoadingPlaceholder from '$lib/components/ui/LoadingPlaceholder.svelte';
   import { END_AVOIDING_REFERENCE, URL_PATH_GEOGRAPHY, URL_PATH_INDICATOR, URL_PATH_STUDY_LOCATION } from '$config';
   import { fetchData } from '$lib/api/api';
   import Text from './Text.svelte';
+  import ImpactLevel from './ImpactLevel.svelte';
   import Message from '$lib/components/ui/Message.svelte';
   import { mean } from 'd3-array';
   import { round, floor, ceil } from 'lodash-es';
+  import { writable } from 'svelte/store';
 
-  export let store;
+  const store = writable({});
 
   $: !$IS_EMPTY_GEOGRAPHY &&
     !$IS_EMPTY_INDICATOR &&
@@ -37,7 +39,7 @@
     return ceil(Math.floor((v + offset) / step) * step, decimals);
   }
 
-  $: process = ({ data }, { scenarios, urlParams }) => {
+  $: process = ({ data }) => {
     const countable = data.data.countable;
     const step = data.data.impact_levels.step;
     const average_value = data.data.average_value;
@@ -46,29 +48,28 @@
     const [totalMin, totalMax] = data.data.impact_levels.total;
     const offset = Math.min(0, totalMin) * -1;
     const defaultValue = round(Math.round(mean([min + offset, max + offset]) / step) * step, decimals);
-    return {
-      data: {
-        step,
-        min: floorNumber(min, offset, step, decimals),
-        max: ceilNumber(max, offset, step, decimals),
-        totalMin: floorNumber(totalMin, offset, step, decimals),
-        totalMax: ceilNumber(totalMax, offset, step, decimals),
-        defaultValue,
-        offset,
-        average_value,
-        decimals,
-        countable,
-      },
+    const processed = {
+      step,
+      min: floorNumber(min, offset, step, decimals),
+      max: ceilNumber(max, offset, step, decimals),
+      totalMin: floorNumber(totalMin, offset, step, decimals),
+      totalMax: ceilNumber(totalMax, offset, step, decimals),
+      defaultValue,
+      offset,
+      average_value,
+      decimals,
+      countable,
     };
+    REFERENCE_PROCESSED.set(processed);
+    return { data: processed };
   };
 </script>
 
-<div class="flex flex-col gap-y-6 md:min-h-[240px]">
+<div class="flex flex-col gap-y-6">
   {#if !$IS_EMPTY_GEOGRAPHY && !$IS_EMPTY_INDICATOR && $IS_COMBINATION_AVAILABLE_INDICATOR}
     <LoadingWrapper
       {process}
       let:asyncProps={{ data }}
-      let:props
       asyncProps={{
         data: $store,
       }}
@@ -78,7 +79,7 @@
       warningSizeSmall={true}
       warningBackground={false}
     >
-      <Text {data} />
+      <ImpactLevel {data} />
 
       <LoadingPlaceholder slot="placeholder" />
     </LoadingWrapper>

--- a/src/routes/(default)/impacts/avoid/components/Reference/Slider/Knob.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/Slider/Knob.svelte
@@ -1,0 +1,5 @@
+<svg class="pointer-events-none" width="9" height="13" viewBox="0 0 11 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0.553223 0.770508V13.1505" stroke="currentColor" />
+  <path d="M5.05322 0.770508V13.1505" stroke="currentColor" />
+  <path d="M9.55322 0.770508V13.1505" stroke="currentColor" />
+</svg>

--- a/src/routes/(default)/impacts/avoid/components/Reference/Text.svelte
+++ b/src/routes/(default)/impacts/avoid/components/Reference/Text.svelte
@@ -1,26 +1,31 @@
 <script>
   import { CURRENT_INDICATOR_LABEL, CURRENT_INDICATOR, CURRENT_GEOGRAPHY, CURRENT_INDICATOR_OPTIONS } from '$stores/state.js';
-  import { IS_STUDY_LOCATION_WHOLE_URBAN_AREA, SELECTED_STUDY_LOCATION_LABEL } from '$stores/avoid.js';
+  import { IS_STUDY_LOCATION_WHOLE_URBAN_AREA, SELECTED_STUDY_LOCATION_LABEL, REFERENCE_PROCESSED } from '$stores/avoid.js';
   import { formatValue, formatUnit } from '$lib/utils/formatting';
-  export let data;
+  import Interactive from '../ThresholdLevels/Interactive.svelte';
 
-  $: ({ unit } = $CURRENT_INDICATOR);
-  $: ({ labelWithinSentence } = $CURRENT_INDICATOR_LABEL);
-  $: ({ average_value, countable } = data);
-  $: ({ reference } = $CURRENT_INDICATOR_OPTIONS);
+  $: ({ unit } = $CURRENT_INDICATOR ?? {});
+  $: ({ labelWithinSentence } = $CURRENT_INDICATOR_LABEL ?? {});
+  $: ({ average_value, countable } = $REFERENCE_PROCESSED ?? {});
+  $: ({ reference } = $CURRENT_INDICATOR_OPTIONS ?? {});
   $: isWholeUrbanArea = $IS_STUDY_LOCATION_WHOLE_URBAN_AREA;
-  $: period = reference.labelAvoid ?? reference.label;
-  $: value = formatValue(average_value, unit.uid);
-  $: location = `${isWholeUrbanArea ? '<strong>urban area</strong> of ' : '<strong>' + $SELECTED_STUDY_LOCATION_LABEL + '</strong> in '} <strong>${$CURRENT_GEOGRAPHY.label}</strong>`;
+  $: period = reference?.labelAvoid ?? reference?.label;
+  $: value = formatValue(average_value, unit?.uid);
 </script>
 
-<div>
-  <strong>What impacts are you trying to avoid?</strong>
-  <p class="text-text-weaker text-sm mr-2">
-    {#if countable}
-      Over the {period} period, the {@html location} experienced on average <strong>{@html value}</strong> <strong>{labelWithinSentence}</strong>.
-    {:else}
-      Over the {period} period, the {@html location} experienced <strong>{labelWithinSentence}</strong> of <strong>{value}{@html formatUnit(unit)}</strong>.
-    {/if}
-  </p>
-</div>
+{#if $REFERENCE_PROCESSED}
+<p class="text-lg leading-relaxed max-w-4xl">
+  Over the <Interactive>{period}</Interactive> period, the
+  {#if isWholeUrbanArea}
+    <Interactive>urban area</Interactive> of <Interactive>{$CURRENT_GEOGRAPHY?.label}</Interactive>
+  {:else}
+    <Interactive>{$SELECTED_STUDY_LOCATION_LABEL}</Interactive> in <Interactive>{$CURRENT_GEOGRAPHY?.label}</Interactive>
+  {/if}
+  experienced
+  {#if countable}
+    on average <Interactive>{@html value}</Interactive> <Interactive>{labelWithinSentence}</Interactive>.
+  {:else}
+    <Interactive>{labelWithinSentence}</Interactive> of <Interactive>{value}{@html formatUnit(unit)}</Interactive>.
+  {/if}
+</p>
+{/if}

--- a/src/routes/(default)/impacts/avoid/components/ThresholdLevels/Text.svelte
+++ b/src/routes/(default)/impacts/avoid/components/ThresholdLevels/Text.svelte
@@ -7,6 +7,7 @@
   import Interactive from './Interactive.svelte';
   import Important from './Important.svelte';
   import { formatValue, formatUnit } from '$lib/utils/formatting';
+  import ReferenceText from '../Reference/Text.svelte';
   export let data;
 
   const VALUE_NEVER = 'never';
@@ -48,6 +49,7 @@
 </script>
 
 <div class="flex gap-y-12 flex-col mb-4">
+  <ReferenceText />
   <section class="flex gap-y-4 flex-col">
     <p class="text-lg leading-relaxed max-w-4xl">
       {#if isAvoidable}

--- a/src/stores/avoid.js
+++ b/src/stores/avoid.js
@@ -97,6 +97,7 @@ LEVEL_OF_IMPACT_ARRAY.subscribe((value) => {
 });
 
 export const LEVEL_OF_IMPACT = writable(0);
+export const REFERENCE_PROCESSED = writable(null);
 
 export const IS_EMPTY_LEVEL_OF_IMPACT = derived(LEVEL_OF_IMPACT, ($value) => typeof $value === 'undefined');
 export const IS_EMPTY_LIKELIHOOD_LEVEL = derived(SELECTED_LIKELIHOOD_LEVEL, ($value) => !Boolean($value));


### PR DESCRIPTION
## Summary
- Adds `REFERENCE_PROCESSED` store to `avoid.js` to share processed reference API data across components without prop drilling
- `Reference.svelte` now internalises its own store (no need to pass `store={...}` from the page) and writes processed data to `REFERENCE_PROCESSED`
- `Reference/Text.svelte` reads from the store directly, uses `Interactive` chip styling to match the surrounding ThresholdLevels text
- Reference context sentence ("Over the X period, the Y location experienced...") renders as the first line inside the ThresholdLevels text section
- ImpactLevel slider remains in the filters bar via `<Reference />`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)