### PR TITLE
Rename navigation label to Case Studies

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,7 @@ export const LABEL_EXPLORE = 'Explore';
 export const LABEL_KEY_CONCEPTS = 'Key concepts';
 export const LABEL_FUTURE_IMPACTS = 'Future impacts';
 export const LABEL_AVOID_IMPACTS = 'Avoiding future impacts';
-export const LABEL_ADAPTATION = 'Adaptation';
+export const LABEL_ADAPTATION = 'Case Studies';
 
 export const LABEL_SCENARIOS_INTRO = 'Scenarios';
 export const LABEL_SCENARIOS_TIMEFRAMES = 'Timeframes';

--- a/src/routes/(default)/adaptation/+page.svelte
+++ b/src/routes/(default)/adaptation/+page.svelte
@@ -55,7 +55,7 @@
 <ContentPageLayout
   {sections}
   label={LABEL_ADAPTATION}
-  title="Tools"
+  title="Adaptation"
   intro="Tools and resources for using climate data in risk assessment and planning."
 >
   <Outro title={data.outroTitle} text={data.outroText} />


### PR DESCRIPTION
## Summary
- Renames the Adaptation nav link label to "Case Studies"
- Restores the adaptation page hero title to "Adaptation" (was "Tools")

## Test plan
- [ ] Navigation shows "Case Studies" link
- [ ] Adaptation page hero displays "Adaptation" as the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)