### PR TITLE
fix: align active border indicator styles across nav components

### DIFF
--- a/src/lib/components/navigation/NestedNav.svelte
+++ b/src/lib/components/navigation/NestedNav.svelte
@@ -157,31 +157,40 @@
   };
 </script>
 
-<nav class="flex flex-col gap-6 mr-12">
+<nav class="flex flex-col gap-6">
   {#if title}
     <h2 class="font-display text-xs uppercase text-theme-800 font-semibold tracking-wide">{title}</h2>
   {/if}
   <ul data-index={effectiveActiveIndex}>
     {#each processedSections as { title, slug, isActive, index, isOpen, sections, hasContent }}
       {#if hasContent}
-        <li class="py-2 border-b border-contour-weakest pr-1">
-          <div aria-expanded={String(isActive)} class:text-theme-base={isActive} class="flex justify-between items-center">
-            <a class="font-semibold text-sm" href={`#${slug}`}>{title}</a>
-            {#if sections.length}
-              <button as="button" class="p-1" class:rotate-180={isOpen} on:click={() => toggleSection(index)}>▾</button>
+        <li class="border-r-3 pr-12"
+          class:border-r-theme-base={isActive && (!isOpen || !sections.length)}
+          class:border-r-transparent={!isActive || (isOpen && sections.length)}
+        >
+          <div class="py-2 border-b border-contour-weakest">
+            <div aria-expanded={String(isActive)} class:text-theme-base={isActive} class="flex justify-between items-center">
+              <a class="font-semibold text-sm" href={`#${slug}`}>{title}</a>
+              {#if sections.length}
+                <button as="button" class="p-1" class:rotate-180={isOpen} on:click={() => toggleSection(index)}>▾</button>
+              {/if}
+            </div>
+            {#if sections.length && isOpen}
+              <ul>
+                {#each sections as { slug, title, isActive }}
+                  <li class="mt-1 relative">
+                    <a aria-current={isActive ? 'step' : 'false'} class="inline-block text-sm font-normal py-1 leading-tight" class:text-theme-base={isActive} href={`#${slug}`}>
+                      {title}
+                    </a>
+                    <span class="absolute inset-y-0 -right-[3.2rem] border-r-3"
+                      class:border-r-theme-base={isActive}
+                      class:border-r-transparent={!isActive}
+                    ></span>
+                  </li>
+                {/each}
+              </ul>
             {/if}
           </div>
-          {#if sections.length}
-            <ul class:h-0={!isOpen} class="overflow-hidden">
-              {#each sections as { slug, title, isActive }}
-                <li class="mt-1">
-                  <a aria-current={isActive ? 'step' : 'false'} class="inline-block text-sm font-normal py-1 leading-tight" class:text-theme-base={isActive} href={`#${slug}`}>
-                    {title}
-                  </a>
-                </li>
-              {/each}
-            </ul>
-          {/if}
         </li>
       {/if}
     {/each}

--- a/src/lib/components/navigation/SimpleNav.svelte
+++ b/src/lib/components/navigation/SimpleNav.svelte
@@ -14,9 +14,9 @@
     class:pointer-events-none={disabled}
     role={disabled ? 'link' : undefined}
     href={disabled ? undefined : `#${slug}`}
-    class="md:inline-block py-3 pl-2 -ml-2 pr-6 lg:pr-12 border-r-3 hover:bg-surface-weaker"
-    class:border-theme-base={isActive}
-    class:border-transparent={!isActive}
+    class="md:inline-block py-3 pl-2 -ml-2 pr-12 border-r-3 hover:bg-surface-weaker"
+    class:border-r-theme-base={isActive}
+    class:border-r-transparent={!isActive}
     aria-current={isActive ? 'step' : 'false'}
   >
     <div class="font-bold mb-1 -mt-1 leading-tight" class:text-theme-base={isActive && !disabled}>


### PR DESCRIPTION
## Summary

- Refactors `NestedNav` active border: moves indicator to `border-r-3` on the `<li>` with `border-r-theme-base`/`border-r-transparent`, and fixes sub-section indicator positioning with an absolutely-positioned `<span>`
- Removes `mr-12` from the `NestedNav` container (spacing now handled by `pr-12` on items)
- Aligns `SimpleNav` to the same pattern: `border-r-theme-base`/`border-r-transparent` and consistent `pr-12`

## Test plan

- [ ] Check `NestedNav` active border appears on top-level items and hides when a sub-section dropdown is open
- [ ] Check `NestedNav` sub-section active border indicator renders correctly
- [ ] Check `SimpleNav` active border appears correctly on active items

🤖 Generated with [Claude Code](https://claude.com/claude-code)