### PR TITLE
refactor: redesign footer as 3-column layout

### DIFF
--- a/src/lib/components/site/Footer.svelte
+++ b/src/lib/components/site/Footer.svelte
@@ -5,54 +5,43 @@
 </script>
 
 <footer class="bg-surface-weaker border-t border-contour-weakest">
-  <div class="mx-auto max-w-7xl px-6 py-12 flex flex-col gap-12">
+  <div class="mx-auto max-w-7xl px-6 py-10 grid grid-cols-1 md:grid-cols-3 gap-12 md:items-start">
 
-    <!-- Top: Logo + Description | Nav -->
-    <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-8">
-      <!-- Left: Logo + Description -->
-      <div class="max-w-sm">
-        <div class="inline-flex gap-3 text-md">
-          <span class="text-theme-stronger font-bold uppercase tracking-widest">
-            {TITLE_PROJECT}
-          </span>
-          <span class="text-theme-stronger" role="presentation" aria-hidden="true">|</span>
-          <span class="text-theme-stronger">{TITLE_SITE}</span>
-        </div>
-        <p class="mt-4 text-sm text-theme-stronger">
-          The development of the dashboard was led by <a
-            href="https://iiasa.ac.at/"
-            class="underline decoration-theme-base hover:text-theme-stronger hover:decoration-theme-stronger transition-colors">IIASA</a
-          >, with contributions from the
-          <a href="https://www.provide-h2020.eu/" class="underline decoration-theme-base hover:text-theme-stronger hover:decoration-theme-stronger transition-colors">PROVIDE</a> consortium.
-        </p>
+    <!-- Left: Logo + Description -->
+    <div>
+      <div class="inline-flex gap-3 text-md">
+        <span class="text-theme-stronger font-bold uppercase tracking-widest">{TITLE_PROJECT}</span>
+        <span class="text-theme-stronger" role="presentation" aria-hidden="true">|</span>
+        <span class="text-theme-stronger">{TITLE_SITE}</span>
       </div>
-
-      <!-- Right: Navigation Links -->
-      <nav>
-        <ul class="flex flex-wrap gap-x-6 gap-y-2">
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_IMPACT}/{PATH_EXPLORE}">{LABEL_EXPLORE}</a></li>
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ADAPTATION}">{LABEL_ADAPTATION}</a></li>
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ADAPTATION}">Case Studies</a></li>
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_DOCUMENTATION}">{LABEL_DOCUMENTATION}</a></li>
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ABOUT}">{LABEL_ABOUT}</a></li>
-          <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_CONTACT}">{LABEL_CONTACT}</a></li>
-        </ul>
-      </nav>
+      <p class="mt-3 text-sm text-theme-stronger max-w-xs">
+        The development of the dashboard was led by <a
+          href="https://iiasa.ac.at/"
+          class="underline decoration-theme-base hover:text-theme-stronger hover:decoration-theme-stronger transition-colors">IIASA</a
+        >, with contributions from the
+        <a href="https://www.provide-h2020.eu/" class="underline decoration-theme-base hover:text-theme-stronger hover:decoration-theme-stronger transition-colors">PROVIDE</a> consortium.
+      </p>
     </div>
 
-    <!-- Bottom: EU Funding Badges -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-      <div class="flex gap-x-4 items-start">
-        <img
-          class="w-16 flex-shrink-0"
-          alt="Logo of the European Union"
-          src="/img/eu-flag.svg"
-        />
-        <p class="text-xs text-text-weaker">
-          This project has received funding from the European Union's Horizon 2020 research and innovation programme under grant agreement No. 101003687.
-        </p>
-      </div>
+    <!-- Middle: EU Funding -->
+    <div class="flex gap-x-3 items-start">
+      <img class="w-12 flex-shrink-0" alt="Logo of the European Union" src="/img/eu-flag.svg" />
+      <p class="text-xs text-text-weaker">
+        This project has received funding from the European Union's Horizon 2020 research and innovation programme under grant agreement No. 101003687.
+      </p>
     </div>
+
+    <!-- Right: Navigation Links -->
+    <nav class="md:pl-32">
+      <ul class="flex flex-col gap-y-2">
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_IMPACT}/{PATH_EXPLORE}">{LABEL_EXPLORE}</a></li>
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ADAPTATION}">{LABEL_ADAPTATION}</a></li>
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ADAPTATION}">Case Studies</a></li>
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_DOCUMENTATION}">{LABEL_DOCUMENTATION}</a></li>
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_ABOUT}">{LABEL_ABOUT}</a></li>
+        <li><a class="text-sm text-theme-stronger hover:underline transition-colors" href="/{PATH_CONTACT}">{LABEL_CONTACT}</a></li>
+      </ul>
+    </nav>
 
   </div>
 


### PR DESCRIPTION
## Summary

- Replaces the stacked two-section footer (logo/nav row + EU badge row) with a single 3-column grid
- Left: project title and description (constrained to `max-w-xs`)
- Centre: EU flag + funding acknowledgement
- Right: stacked navigation links with left-column indent

## Test plan

- [ ] Check 3-column layout renders correctly on desktop
- [ ] Check columns stack correctly on mobile
- [ ] Check bottom bar (version/build info) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)