### PR TITLE
Restyle html-content .btn links

### DIFF
--- a/src/styles/app.postcss
+++ b/src/styles/app.postcss
@@ -35,11 +35,24 @@ html {
       @apply no-underline;
       @apply border-b-0;
       @apply py-2;
-      @apply px-3;
-      @apply bg-surface-weakest;
-      @apply my-1;
-      @apply inline-block;
-      @apply hover:bg-theme-weakest;
+      @apply px-4;
+      @apply bg-petrol-100;
+      @apply text-theme-base;
+      @apply font-bold;
+      @apply text-sm;
+      @apply rounded-sm;
+      @apply my-3;
+      @apply flex;
+      @apply max-w-[350px];
+      @apply items-center;
+      @apply justify-between;
+      @apply hover:bg-theme-base;
+      @apply hover:text-white;
+
+      &::after {
+        content: '→';
+        @apply font-normal;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Updates the `.btn` anchor class used in CMS-rendered HTML content (e.g. contact page newsletter links) to match the secondary `Button` component style
- Flex layout with text on the left and `→` arrow on the right via `::after`
- `bg-petrol-100` background, bold text, `max-width: 350px`
- Hover transitions to `bg-theme-base` / white text

## Test plan

- [ ] Visit the contact page and confirm newsletter links render with the new button style
- [ ] Confirm arrow appears on the right and text on the left
- [ ] Hover each button and confirm background/text colour transition
- [ ] Check other pages using `.html-content` with `.btn` links are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)