### PR TITLE
fix: anchor selection modals to top with min/max height

### DIFF
--- a/src/lib/components/ui/ModalSelect.svelte
+++ b/src/lib/components/ui/ModalSelect.svelte
@@ -10,9 +10,9 @@
 <Dialog open={isOpen} on:close={() => (isOpen = false)} class="relative z-50">
   <DialogOverlay class="fixed inset-0 bg-black/40" />
   <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
-  <div class="fixed inset-0 flex items-center justify-center p-4" on:click={() => (isOpen = false)}>
+  <div class="fixed inset-0 flex items-start justify-center px-4 pt-[5vh] pb-4" on:click={() => (isOpen = false)}>
     <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
-    <div class={`${panelClass} relative bg-surface-base rounded overflow-hidden border border-contour-weakest shadow-xl w-full max-h-[95vh] flex flex-col`} on:click|stopPropagation>
+    <div class={`${panelClass} relative bg-surface-base rounded overflow-hidden border border-contour-weakest shadow-xl w-full min-h-[90vh] max-h-[90vh] flex flex-col`} on:click|stopPropagation>
       <div class="absolute top-3 right-3 z-10">
         <button on:click={() => (isOpen = false)} aria-label="Close" class="text-contour-weak hover:text-theme-base transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>


### PR DESCRIPTION
## Summary

- Selection modals (Geography and Indicator) now anchor to the top of the viewport at a fixed 5vh offset rather than centring vertically
- Added `min-h-[90vh]` and `max-h-[90vh]` so modals fill most of the screen height and scroll internally when content overflows
- Change is in the shared `ModalSelect` component, so both modals get the updated behaviour automatically

## Test plan

- [ ] Open the Geography modal and verify it appears near the top of the screen with consistent height
- [ ] Open the Indicator modal and confirm same anchored behaviour
- [ ] Verify the sidebar and content columns scroll independently when lists are long
- [ ] Check that clicking outside the modal (on the overlay) still closes it
- [ ] Test on mobile / narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)