### PR TITLE
fix: prevent null CMS titles showing in case study side menu

### DIFF
--- a/src/lib/components/layouts/SectionContent.svelte
+++ b/src/lib/components/layouts/SectionContent.svelte
@@ -11,21 +11,23 @@
   $: id = slug ?? kebabCase(title);
 </script>
 
-<svelte:element
-  this={as}
-  {id}
-  name={id}
-  class="text-theme-stronger scroll-mt-4 my-4 first:mt-0"
-  class:text-2xl={as === 'h2'}
-  class:text-xs={as === 'h3'}
-  class:font-bold={as === 'h3'}
-  class:uppercase={as === 'h3'}
-  class:tracking-widest={as === 'h3'}
-  class:text-text-weaker={as === 'h3'}
-  class:text-lg={as === 'h4'}
->
-  {title}
-</svelte:element>
+{#if title}
+  <svelte:element
+    this={as}
+    {id}
+    name={id}
+    class="text-theme-stronger scroll-mt-4 my-4 first:mt-0"
+    class:text-2xl={as === 'h2'}
+    class:text-xs={as === 'h3'}
+    class:font-bold={as === 'h3'}
+    class:uppercase={as === 'h3'}
+    class:tracking-widest={as === 'h3'}
+    class:text-text-weaker={as === 'h3'}
+    class:text-lg={as === 'h4'}
+  >
+    {title}
+  </svelte:element>
+{/if}
 
 {#if subtitle}
   <p class="text-sm text-text-weaker mb-2">{subtitle}</p>

--- a/src/lib/components/navigation/NestedNav.svelte
+++ b/src/lib/components/navigation/NestedNav.svelte
@@ -70,7 +70,7 @@
     headingObservers.forEach((o) => o.disconnect());
     headingObservers = [];
 
-    const flatToc = [...headings].map((el, i) => {
+    const flatToc = [...headings].filter((el) => el.innerText.trim()).map((el, i) => {
       const slug = el.getAttribute('id') || slugify(el.innerText);
       el.setAttribute('id', slug);
 


### PR DESCRIPTION
## Summary

- `SectionContent` was rendering `<h2>null</h2>` when a CMS `Title` field was left blank — Svelte coerces `null` to the string `"null"` via `'' + null`. `NestedNav`'s dynamic mode reads `el.innerText` from DOM headings, so "null" was appearing as a side menu entry.
- Fixed by wrapping the heading in `{#if title}` in `SectionContent.svelte`, consistent with how `AvoidingImpacts` already guards its `<h4>`.
- Added a `.filter(el => el.innerText.trim())` in `NestedNav` as a defensive safety net against any other component rendering an empty heading.

## Test plan

- [ ] Open a case study page (e.g. Lisbon) and confirm no "null" entries appear in the side menu
- [ ] Confirm sections with a real title still appear correctly in the side menu and scroll-to works
- [ ] Check other content pages that use `SectionContent` (methodology, key terms) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)