### PR TITLE
refactor: extract scroll-spy into reusable createScrollSpy utility

### DIFF
--- a/src/lib/components/navigation/NestedNav.svelte
+++ b/src/lib/components/navigation/NestedNav.svelte
@@ -1,5 +1,6 @@
 <script>
   import { slugify } from '$lib/utils/utils';
+  import { createScrollSpy } from '$lib/utils/scrollSpy';
   import { onDestroy } from 'svelte';
   import Chevron from '$lib/components/icons/Chevron.svelte';
 
@@ -16,7 +17,12 @@
 
   // Internal active index for dynamic mode (tracks individual headings)
   let dynamicActiveIndex = 0;
-  let headingObservers = [];
+  let headingEls = [];
+  let spy = null;
+
+  function handleNavClick(targetIndex) {
+    spy?.click(targetIndex);
+  }
 
   // Takes a flat array of h2/h3 titles and turns them into a hierarchy
   const createHierarchy = (flatItems) => {
@@ -61,43 +67,30 @@
   };
 
   // If containerRef is given, query all h2/h3 titles from the given container, assign IDs,
-  // set up IntersectionObservers on each heading, and build the nav hierarchy.
+  // set up scroll-spy, and build the nav hierarchy.
   $: dynamicNavSections = (() => {
     if (!contentRef) return;
-    const headings = contentRef?.querySelectorAll('h2, h3');
 
-    // Clean up previous observers
-    headingObservers.forEach((o) => o.disconnect());
-    headingObservers = [];
+    spy?.destroy();
 
-    const flatToc = [...headings].filter((el) => el.innerText.trim()).map((el, i) => {
-      const slug = el.getAttribute('id') || slugify(el.innerText);
-      el.setAttribute('id', slug);
-
-      // Observe each heading individually so activeIndex tracks heading index, not section index
-      const io = new IntersectionObserver(
-        ([e]) => { if (e.isIntersecting) dynamicActiveIndex = i; },
-        { threshold: 0.5 }
-      );
-      io.observe(el);
-      headingObservers.push(io);
-
-      return {
-        props: {
-          title: el.innerText,
-          slug,
-        },
-        level: parseFloat(el.tagName[1]),
-        content: true,
-      };
+    headingEls = [...contentRef.querySelectorAll('h2, h3')].filter((el) => el.innerText.trim());
+    headingEls.forEach((el) => {
+      el.setAttribute('id', el.getAttribute('id') || slugify(el.innerText));
     });
 
-    return createHierarchy(flatToc);
+    spy = createScrollSpy(contentRef, {
+      getItems: () => headingEls,
+      onActive: (i) => { dynamicActiveIndex = i; },
+    });
+
+    return createHierarchy(headingEls.map((el) => ({
+      props: { title: el.innerText, slug: el.getAttribute('id') },
+      level: parseFloat(el.tagName[1]),
+      content: true,
+    })));
   })();
 
-  onDestroy(() => {
-    headingObservers.forEach((o) => o.disconnect());
-  });
+  onDestroy(() => spy?.destroy());
 
   // In dynamic mode use the internally tracked heading index;
   // in static mode use the activeIndex prop (tracks top-level sections).
@@ -171,16 +164,16 @@
         >
           <div class="py-2 border-b border-contour-weakest">
             <div aria-expanded={String(isActive)} class:text-theme-base={isActive} class="flex justify-between items-center">
-              <a class="font-semibold text-sm" href={`#${slug}`}>{title}</a>
+              <a class="font-semibold text-sm" href={`#${slug}`} on:click={() => handleNavClick(index)}>{title}</a>
               {#if sections.length}
                 <button as="button" class="p-1 transition-transform duration-150" class:rotate-180={isOpen} on:click={() => toggleSection(index)}><Chevron /></button>
               {/if}
             </div>
             {#if sections.length && isOpen}
               <ul>
-                {#each sections as { slug, title, isActive }}
+                {#each sections as { slug, title, isActive, index: subIndex }}
                   <li class="mt-1 relative">
-                    <a aria-current={isActive ? 'step' : 'false'} class="inline-block text-sm font-normal py-1 leading-tight" class:text-theme-base={isActive} href={`#${slug}`}>
+                    <a aria-current={isActive ? 'step' : 'false'} class="inline-block text-sm font-normal py-1 leading-tight" class:text-theme-base={isActive} href={`#${slug}`} on:click={() => handleNavClick(subIndex)}>
                       {title}
                     </a>
                     <span class="absolute inset-y-0 -right-[3.2rem] border-r-3"

--- a/src/lib/components/navigation/SimpleNav.svelte
+++ b/src/lib/components/navigation/SimpleNav.svelte
@@ -1,6 +1,7 @@
 <script>
   export let sections = [];
   export let activeIndex = 0;
+  export let onNavClick = undefined;
   // role="link" -> https://www.scottohara.me/blog/2021/05/28/disabled-links.html
 </script>
 
@@ -14,6 +15,7 @@
     class:pointer-events-none={disabled}
     role={disabled ? 'link' : undefined}
     href={disabled ? undefined : `#${slug}`}
+    on:click={onNavClick && !disabled ? () => onNavClick(i) : undefined}
     class="md:inline-block py-3 pl-2 -ml-2 pr-12 border-r-3 hover:bg-surface-weaker"
     class:border-r-theme-base={isActive}
     class:border-r-transparent={!isActive}

--- a/src/lib/utils/scrollSpy.js
+++ b/src/lib/utils/scrollSpy.js
@@ -1,0 +1,65 @@
+function findScrollParent(el) {
+  while (el && el !== document.documentElement) {
+    const { overflow, overflowY } = window.getComputedStyle(el);
+    if (/(auto|scroll)/.test(overflow + overflowY)) return el;
+    el = el.parentElement;
+  }
+  return document.documentElement;
+}
+
+/**
+ * Creates a scroll-spy instance attached to a container element.
+ *
+ * @param {Element} node - The container element to observe.
+ * @param {object} opts
+ * @param {() => (Element|string|null)[]} opts.getItems
+ *   Called on every scroll tick. Return an array whose indices match the indices
+ *   you want passed to onActive. Items can be DOM Elements, id strings, or null
+ *   (nulls are skipped so you can align with a full array including disabled items).
+ * @param {(index: number) => void} opts.onActive - Called with the index of the active item.
+ * @returns {{ destroy: () => void, click: (index: number) => void }}
+ */
+export function createScrollSpy(node, { getItems, onActive }) {
+  let isClickScrolling = false;
+  const scrollContainer = findScrollParent(node);
+
+  function update() {
+    if (isClickScrolling) return;
+    const midpoint = window.innerHeight / 2;
+    getItems().forEach((item, i) => {
+      if (!item) return;
+      const el = item instanceof Element ? item : document.getElementById(item);
+      if (el && el.getBoundingClientRect().top <= midpoint) onActive(i);
+    });
+  }
+
+  function onUserScroll() { isClickScrolling = false; }
+
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      scrollContainer.addEventListener('scroll', update, { passive: true });
+      scrollContainer.addEventListener('wheel', onUserScroll, { passive: true });
+      scrollContainer.addEventListener('touchmove', onUserScroll, { passive: true });
+      update();
+    } else {
+      scrollContainer.removeEventListener('scroll', update);
+      scrollContainer.removeEventListener('wheel', onUserScroll);
+      scrollContainer.removeEventListener('touchmove', onUserScroll);
+    }
+  });
+  observer.observe(node);
+
+  function destroy() {
+    observer.disconnect();
+    scrollContainer.removeEventListener('scroll', update);
+    scrollContainer.removeEventListener('wheel', onUserScroll);
+    scrollContainer.removeEventListener('touchmove', onUserScroll);
+  }
+
+  function click(i) {
+    isClickScrolling = true;
+    onActive(i);
+  }
+
+  return { destroy, click };
+}

--- a/src/routes/(default)/impacts/avoid/+page.svelte
+++ b/src/routes/(default)/impacts/avoid/+page.svelte
@@ -14,6 +14,7 @@
   import Reference from './components/Reference/Reference.svelte';
   import PageLayout from '$lib/components/layouts/PageLayout.svelte';
   import { onMount, onDestroy } from 'svelte';
+  import { createScrollSpy } from '$lib/utils/scrollSpy';
   import ShareLink from '../components/ShareLink/ShareLink.svelte';
   import Button from '$lib/components/ui/Button.svelte';
   import LinkArrow from '$lib/components/icons/LinkArrow.svelte';
@@ -59,15 +60,20 @@
   ];
 
   let activeIndex = 0;
+  let contentEl;
+  let spy = null;
 
-  function observeSection(node, index) {
-    const io = new IntersectionObserver(
-      ([e]) => { if (e.isIntersecting) activeIndex = index; },
-      { threshold: 0.1 }
-    );
-    io.observe(node);
-    return { destroy: () => io.disconnect() };
+  $: if (contentEl) {
+    spy?.destroy();
+    spy = createScrollSpy(contentEl, {
+      getItems: () => sections.map((s) => (s.slug && !s.disabled ? document.getElementById(s.slug) : null)),
+      onActive: (i) => { activeIndex = i; },
+    });
   }
+
+  function handleNavClick(i) { spy?.click(i); }
+
+  onDestroy(() => spy?.destroy());
 </script>
 
 <PageLayout>
@@ -91,7 +97,7 @@
 
   <svelte:fragment slot="sidebar">
     <h2 class="font-display text-xs uppercase text-theme-800 font-semibold tracking-wide">Report Index</h2>
-    <SimpleNav {sections} {activeIndex} />
+    <SimpleNav {sections} {activeIndex} onNavClick={handleNavClick} />
     <hr class="my-4 border-contour-weakest mr-6" />
     <ShareLink />
     <Button class="mt-4 mr-6" href="/methodology" variant="secondary">
@@ -108,9 +114,10 @@
   </svelte:fragment>
 
   <svelte:fragment slot="content">
+    <div bind:this={contentEl}>
     {#each sections as section, i}
       {#if !section.disabled}
-        <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-8 pb-8 -mx-6 px-6 border-b border-contour-weakest last:border-none">
+        <section id={section.slug} name={section.slug} class="scroll-mt-4 mb-8 pb-8 -mx-6 px-6 border-b border-contour-weakest last:border-none">
           <svelte:component this={section.component} {...section.props} />
         </section>
       {/if}
@@ -118,5 +125,6 @@
     {#if !$IS_STATIC && $CURRENT_GEOGRAPHY}
       <LinkSection geography={$CURRENT_GEOGRAPHY} {caseStudy} />
     {/if}
+    </div>
   </svelte:fragment>
 </PageLayout>

--- a/src/routes/(default)/impacts/explore/+page.svelte
+++ b/src/routes/(default)/impacts/explore/+page.svelte
@@ -14,6 +14,8 @@
   import PageHero from '$lib/components/layouts/PageHero.svelte';
   import PageLayout from '$lib/components/layouts/PageLayout.svelte';
   import SimpleNav from '$lib/components/navigation/SimpleNav.svelte';
+  import { onDestroy } from 'svelte';
+  import { createScrollSpy } from '$lib/utils/scrollSpy';
   import ShareLink from '../components/ShareLink/ShareLink.svelte';
   import Button from '$lib/components/ui/Button.svelte';
   import LinkArrow from '$lib/components/icons/LinkArrow.svelte';
@@ -59,15 +61,20 @@
   ];
 
   let activeIndex = 0;
+  let contentEl;
+  let spy = null;
 
-  function observeSection(node, index) {
-    const io = new IntersectionObserver(
-      ([e]) => { if (e.isIntersecting) activeIndex = index; },
-      { threshold: 0.1 }
-    );
-    io.observe(node);
-    return { destroy: () => io.disconnect() };
+  $: if (contentEl) {
+    spy?.destroy();
+    spy = createScrollSpy(contentEl, {
+      getItems: () => sections.map((s) => (s.slug && !s.disabled ? document.getElementById(s.slug) : null)),
+      onActive: (i) => { activeIndex = i; },
+    });
   }
+
+  function handleNavClick(i) { spy?.click(i); }
+
+  onDestroy(() => spy?.destroy());
 </script>
 
 <PageLayout>
@@ -88,7 +95,7 @@
 
   <svelte:fragment slot="sidebar">
     <h2 class="font-display text-xs uppercase text-theme-800 font-semibold tracking-wide">Report Index</h2>
-    <SimpleNav {sections} {activeIndex} />
+    <SimpleNav {sections} {activeIndex} onNavClick={handleNavClick} />
     <hr class="my-4 border-contour-weakest mr-6" />
     <ShareLink />
     <Button class="mt-4 mr-6" href="/methodology" variant="secondary">
@@ -107,9 +114,10 @@
   </svelte:fragment>
 
   <svelte:fragment slot="content">
+    <div bind:this={contentEl}>
     {#each sections as section, i}
       {#if !section.disabled}
-        <section use:observeSection={i} id={section.slug} name={section.slug} class="scroll-mt-4 mb-8 pb-8 -mx-6 px-6 border-contour-weakest border-b last:border-none">
+        <section id={section.slug} name={section.slug} class="scroll-mt-4 mb-8 pb-8 -mx-6 px-6 border-contour-weakest border-b last:border-none">
           <svelte:component this={section.component} {...section.props} />
         </section>
         {#if section.slug === 'impact-geo' && !$IS_STATIC && $CURRENT_GEOGRAPHY}
@@ -128,5 +136,6 @@
         </Button>
       </div>
     {/if}
+    </div>
   </svelte:fragment>
 </PageLayout>


### PR DESCRIPTION
## Summary

- Replaces three separate copies of per-element `IntersectionObserver` scroll-spy with a single `createScrollSpy()` factory in [`src/lib/utils/scrollSpy.js`](src/lib/utils/scrollSpy.js)
- The utility uses one `IntersectionObserver` on the content container to toggle a scroll listener on/off, then `getBoundingClientRect()` on each scroll tick for pinpoint active-link accuracy
- Adds a click-lock: clicking a nav link immediately sets that item active and suspends scroll tracking until the user manually scrolls again (`wheel`/`touchmove`), preventing the programmatic scroll from fighting the selection
- Adds optional `onNavClick` prop to `SimpleNav` to wire up the click-lock from the explore and avoid pages
- `NestedNav`, `explore/+page.svelte`, and `avoid/+page.svelte` all reduce to a few lines of wiring

## Test plan

- [ ] Explore page: scroll through sections and confirm active nav link updates accurately
- [ ] Explore page: click a nav link, confirm it activates immediately, then scroll and confirm tracking resumes
- [ ] Avoid page: same checks as above
- [ ] Case study page (e.g. Lisbon): scroll through content, confirm NestedNav active heading tracks correctly and click-to-section works

🤖 Generated with [Claude Code](https://claude.com/claude-code)