### PR TITLE
fix: correct typo in hero CTA button text

### DIFF
--- a/src/routes/(default)/landing-page/sections/SectionHero.svelte
+++ b/src/routes/(default)/landing-page/sections/SectionHero.svelte
@@ -25,7 +25,7 @@
         Compare scenarios, explore EU risks, and export evidence for your reports.
       </p>
       <Button on:click={() => goto(`/${PATH_IMPACT}/${PATH_EXPLORE}`)}>
-        Explorer data
+        Explore data
         <LinkArrow />
       </Button>
     </div>


### PR DESCRIPTION
## Summary

- Fixes typo in the landing page hero button: "Explorer data" → "Explore data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)