### PR TITLE
fix: remove sticky positioning from filters bar

### DIFF
--- a/src/lib/components/layouts/PageLayout.svelte
+++ b/src/lib/components/layouts/PageLayout.svelte
@@ -16,7 +16,7 @@
   </div>
   <div class="md:border-l border-contour-weakest border-t md:border-t-0 min-w-0">
     {#if $$slots.filters}
-    <div class="md:sticky z-20" style="top: {navHeight}px">
+    <div class="z-20">
       <div class="flex h-fit bg-white border-b border-contour-weakest [&>*]:border-r [&>*]:border-contour-weakest [&>*]:px-6 [&>*]:py-4">
         <slot name="filters" />
       </div>


### PR DESCRIPTION
## Summary

- Removes `md:sticky` and the dynamic `top` offset from the filters bar in `PageLayout`, so the indicator/scenario filters on the explore and avoid pages scroll with the page instead of remaining fixed below the nav.

## Test plan

- [ ] Visit the explore page, scroll down and confirm the filters bar scrolls away with the content
- [ ] Same check on the avoid page

🤖 Generated with [Claude Code](https://claude.com/claude-code)