### PR TITLE
fix: handle missing Indicators in avoiding-impacts component

### DIFF
--- a/src/routes/(default)/adaptation/[city]/+page.server.js
+++ b/src/routes/(default)/adaptation/[city]/+page.server.js
@@ -30,7 +30,7 @@ export const load = async ({ fetch, parent, params }) => {
   const city = meta.cities.find((c) => c.uid === caseStudyRaw.CityUid);
   if (!city) error(404, { message: 'City not found in data' });
 
-  const loadAvoidingImpactsData = async ({ Indicators, StudyLocations }) => {
+  const loadAvoidingImpactsData = async ({ Indicators = [], StudyLocations = [] }) => {
     // Load all avoiding impacts reference data
     const refRequests = Indicators.map(({ Uid: indicatorUid }) => {
       const indicator = meta.indicators.find((d) => d.uid === indicatorUid);

--- a/src/routes/(default)/adaptation/[city]/sections/AvoidingImpacts.svelte
+++ b/src/routes/(default)/adaptation/[city]/sections/AvoidingImpacts.svelte
@@ -56,6 +56,7 @@
   <PillGroup class="mb-8" label="Study location" size="sm" allowWrap={false} options={studyLocations} bind:currentUid={$studyLocation} />
 {/if}
 
+{#if data.length}
 <table class="w-full mb-10 max-w-[45em]">
   <caption class="caption-bottom text-text-weaker text-sm mt-3 text-left">
     <div class="flex gap-4 justify-between">
@@ -83,3 +84,4 @@
     </tbody>
   {/each}
 </table>
+{/if}


### PR DESCRIPTION
## Summary

- Defaults `Indicators` and `StudyLocations` to `[]` in `loadAvoidingImpactsData` so `.map()` doesn't crash when a case study's avoiding-impacts block has no indicators configured in Strapi
- Guards the `AvoidingImpacts` table render with `{#if data.length}` so the component renders nothing (rather than 500ing) when data is empty

## Test plan

- [ ] Visit `/adaptation/lisbon` — should load without a 500 error
- [ ] Visit another city case study with a populated avoiding-impacts section — table should still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)